### PR TITLE
EASY-1320 with real PDBS bags

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ ARGUMENTS
 
     Options:
 
-        --help      Show help message
-        --version   Show version of this program
+      --help      Show help message
+      --version   Show version of this program
 
     Subcommand: update - Update accessible files of a bag in the SOLR index
       -s, --bag-store  <arg>   Name of the bag store (default = pdbs)
@@ -38,11 +38,11 @@ ARGUMENTS
       bag-uuid (required)
     ---
     
-    Subcommand: delete - Delete all file documents of a bag from the SOLR index
+    Subcommand: delete - Delete documents from the SOLR index; '*:*' deletes all, 'id:<UUID>*' deletes a bag
           --help   Show help message
     
      trailing arguments:
-      bag-uuid (required)
+      solr-query (required)
     ---
     
     Subcommand: init - Rebuild the SOLR index from scratch for active bags in one or all store(s)

--- a/README.md
+++ b/README.md
@@ -6,9 +6,18 @@ easy-update-solr4files-index
 SYNOPSIS
 --------
 
-  easy-update-solr4files-index {update|delete} [-s <bag-store>] <uuid>
-  easy-update-solr4files-index {init} <bag-store>
-  easy-update-solr4files-index run-service
+    easy-update-solr4files-index update [-s <bag-store>] <uuid>
+    easy-update-solr4files-index init <bag-store>
+    easy-update-solr4files-index run-service
+    easy-update-solr4files-index delete <solr-query>
+    
+    Some examples of solr queries:
+    
+      everything:            '*:*'
+      all bags of one store: 'easy_dataset_store_id:pdbs'
+      a bag:                 'easy_dataset_id:ef425828-e4ae-4d58-bf6a-c89cd46df61c'
+      a folder in a bag:     'id:ef425828-e4ae-4d58-bf6a-c89cd46df61c/data/files/Documents/*'
+
 
 DESCRIPTION
 -----------
@@ -38,7 +47,7 @@ ARGUMENTS
       bag-uuid (required)
     ---
     
-    Subcommand: delete - Delete documents from the SOLR index; '*:*' deletes all, 'id:<UUID>*' deletes a bag
+    Subcommand: delete - Delete documents from the SOLR index
           --help   Show help message
     
      trailing arguments:

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -2,4 +2,4 @@ default.bag-store=pdbs
 
 # terminating slashes are required
 vault.url=http://localhost:20110/
-solr.url=http://localhost:8983/solr/easyfiles/
+solr.url=http://localhost:8983/solr/fileitems/

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
@@ -52,7 +52,7 @@ class ApplicationWiring(configuration: Configuration)
       ddmXML <- bag.loadDDM
       ddm = new DDM(ddmXML)
       filesXML <- bag.loadFilesXML
-      _ <- deleteBag(bag.bagId)
+      _ <- deleteDocuments(s"id:${bag.bagId}*")
       feedbackMessage <- updateFiles(bag, ddm, filesXML)
       _ <- commit()
     } yield feedbackMessage
@@ -63,11 +63,11 @@ class ApplicationWiring(configuration: Configuration)
     case t => Failure(t)
   }
 
-  def delete(bagId: String): Try[FeedBackMessage] = {
+  def delete(query: String): Try[FeedBackMessage] = {
     for {
-      _ <- deleteBag(bagId)
+      _ <- deleteDocuments(query)
       _ <- commit()
-    } yield s"Deleted file documents for bag $bagId"
+    } yield s"Deleted documents with query $query"
   }.recoverWith {
     case t: SolrCommitException => Failure(t)
     case t =>

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/Command.scala
@@ -44,7 +44,7 @@ object Command extends App with DebugEnhancedLogging {
     commandLine.subcommand
       .collect {
         case update @ commandLine.update => app.update(update.bagStore(), update.bagUuid())
-        case delete @ commandLine.delete => app.delete(delete.bagUuid())
+        case delete @ commandLine.delete => app.delete(delete.query())
         case init @ commandLine.init => init.bagStore.toOption
           .map(app.initSingleStore)
           .getOrElse(app.initAllStores())

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/CommandLineOptions.scala
@@ -59,8 +59,8 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
     footer(SUBCOMMAND_SEPARATOR)
   }
   val delete = new Subcommand("delete") {
-    descr("Delete all file documents of a bag from the SOLR index")
-    val bagUuid: ScallopOption[UUID] = trailArg(name = "bag-uuid", required = true)
+    descr("Delete documents from the SOLR index; '*:*' deletes all, 'id:<UUID>*' deletes a bag")
+    val query: ScallopOption[UUID] = trailArg(name = "solr-query", required = true)
     footer(SUBCOMMAND_SEPARATOR)
   }
   val init = new Subcommand("init") {

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/CommandLineOptions.scala
@@ -29,9 +29,17 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val description: String = s"""Update the EASY SOLR for Files Index with file data from a bag-store"""
   val synopsis: String =
     s"""
-       |  $printedName {update|delete} [-s <bag-store>] <uuid>
-       |  $printedName {init} <bag-store>
+       |  $printedName update [-s <bag-store>] <uuid>
+       |  $printedName init <bag-store>
        |  $printedName run-service
+       |  $printedName delete <solr-query>
+       |
+       |  Some examples of solr queries:
+       |
+       |    everything:            '*:*'
+       |    all bags of one store: 'easy_dataset_store_id:pdbs'
+       |    a bag:                 'easy_dataset_id:ef425828-e4ae-4d58-bf6a-c89cd46df61c'
+       |    a folder in a bag:     'id:ef425828-e4ae-4d58-bf6a-c89cd46df61c/data/files/Documents/*'
        """.stripMargin
 
   version(s"$printedName v${ configuration.version }")
@@ -59,7 +67,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
     footer(SUBCOMMAND_SEPARATOR)
   }
   val delete = new Subcommand("delete") {
-    descr("Delete documents from the SOLR index; '*:*' deletes all, 'id:<UUID>*' deletes a bag")
+    descr("Delete documents from the SOLR index")
     val query: ScallopOption[UUID] = trailArg(name = "solr-query", required = true)
     footer(SUBCOMMAND_SEPARATOR)
   }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexApp.scala
@@ -28,7 +28,7 @@ class EasyUpdateSolr4filesIndexApp(wiring: ApplicationWiring) extends AutoClosea
 
   def update(storeName: String, bagId: String): Try[String] = wiring.update(storeName, bagId).map(_.toString)
 
-  def delete(bagId: String): Try[String] = wiring.delete(bagId)
+  def delete(query: String): Try[String] = wiring.delete(query)
 
   def init(): Try[Unit] = {
     // Do any initialization of the application here. Typical examples are opening

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Bag.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Bag.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.solr4files.components
 
-import java.net.URL
+import java.net.{ URL, URLEncoder }
 
 import nl.knaw.dans.easy.solr4files.{ FileToShaMap, SolrLiterals, _ }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
@@ -40,7 +40,7 @@ case class Bag(storeName: String,
   }.getOrElse("")
 
   def fileUrl(path: String): Try[URL] = {
-    vault.fileURL(storeName, bagId, path)
+    vault.fileURL(storeName, bagId,  URLEncoder.encode(path,"UTF8"))
   }
 
   private lazy val fileShas: FileToShaMap = {
@@ -66,6 +66,7 @@ case class Bag(storeName: String,
     .flatMap(_.loadXml)
 
   val solrLiterals: SolrLiterals = Seq(
+    ("dataset_store_id", storeName),
     ("dataset_depositor_id", getDepositor),
     ("dataset_id", bagId)
   )

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Bag.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Bag.scala
@@ -21,6 +21,7 @@ import nl.knaw.dans.easy.solr4files.{ FileToShaMap, SolrLiterals, _ }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 import scala.util.Try
+import scala.util.matching.Regex
 import scala.xml.Elem
 
 case class Bag(storeName: String,
@@ -43,12 +44,18 @@ case class Bag(storeName: String,
     vault.fileURL(storeName, bagId,  URLEncoder.encode(path,"UTF8"))
   }
 
+
+  // splits a string on the first sequence of white space after the sha
+  // the rest is a path that might contain white space
+  private lazy val regex: Regex = """(\w+)\s+(.*)""".r()
+
   private lazy val fileShas: FileToShaMap = {
+    // gov.loc.repository.bagit.reader.ManifestReader reads files, we need URL or stream
     for {
       url <- vault.fileURL(storeName, bagId, "manifest-sha1.txt")
       lines <- url.readLines
     } yield lines.map { line: String =>
-      val Array(sha, path) = line.trim.split("""\s+""")
+      val regex(sha, path) = line.trim
       (path, sha)
     }.toMap
   }.getOrElse(Map.empty)

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Bag.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Bag.scala
@@ -41,7 +41,7 @@ case class Bag(storeName: String,
   }.getOrElse("")
 
   def fileUrl(path: String): Try[URL] = {
-    vault.fileURL(storeName, bagId,  URLEncoder.encode(path,"UTF8"))
+    vault.fileURL(storeName, bagId, path)
   }
 
 

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -67,7 +67,7 @@ trait Solr extends DebugEnhancedLogging {
       .recoverWith { case t => Failure(SolrCommitException(t)) }
   }
 
-  private def submitWithContent(fileUrl: URL, solrDocId: String, solrFields: Seq[(FeedBackMessage, FeedBackMessage)]) = {
+  private def submitWithContent(fileUrl: URL, solrDocId: String, solrFields: SolrLiterals) = {
     Try(solrClient.request(new ContentStreamUpdateRequest("/update/extract") {
       setWaitSearcher(false)
       setMethod(METHOD.POST)
@@ -79,12 +79,12 @@ trait Solr extends DebugEnhancedLogging {
     })).flatMap(checkSolrStatus)
   }
 
-  private def resubmitMetadata(solrDocId: String, solrFields: Seq[(FeedBackMessage, FeedBackMessage)]) = {
+  private def resubmitMetadata(solrDocId: String, solrFields: SolrLiterals) = {
     Try(solrClient.add(new SolrInputDocument() {
       solrFields
         .withFilter(_._1 == "easy_dataset_store_id")
         .foreach { case (k, v) =>
-          addField(s"easy_$k", v)
+          addField(s"literal.easy_$k", v)
         }
       addField("id", solrDocId)
     })).map(_.getStatus match {

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -55,10 +55,10 @@ trait Solr extends DebugEnhancedLogging {
   }
 
 
-  def deleteBag(bagId: String): Try[UpdateResponse] = {
+  def deleteDocuments(query: String): Try[UpdateResponse] = {
     // no status to check since UpdateResponse is a stub
-    Try(solrClient.deleteByQuery(createDeleteQuery(bagId)))
-      .recoverWith { case t => Failure(SolrDeleteException(bagId, t)) }
+    Try(solrClient.deleteByQuery(new SolrQuery {set("q", query)}.getQuery))
+      .recoverWith { case t => Failure(SolrDeleteException(query, t)) }
   }
 
   def commit(): Try[UpdateResponse] = {
@@ -95,13 +95,6 @@ trait Solr extends DebugEnhancedLogging {
   }.recoverWith {
     case t2: SolrStatusException => Failure(t2)
     case t2 => Failure(SolrUpdateException(solrDocId, t2))
-  }
-
-
-  private def createDeleteQuery(bagId: String) = {
-    new SolrQuery {
-      set("q", s"id:$bagId/*")
-    }.getQuery
   }
 
   private def checkSolrStatus(namedList: NamedList[AnyRef]) = {

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -19,11 +19,13 @@ import java.net.URL
 
 import nl.knaw.dans.easy.solr4files._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.apache.http.HttpStatus
 import org.apache.solr.client.solrj.SolrRequest.METHOD
 import org.apache.solr.client.solrj.impl.HttpSolrClient
 import org.apache.solr.client.solrj.request.ContentStreamUpdateRequest
 import org.apache.solr.client.solrj.response.UpdateResponse
 import org.apache.solr.client.solrj.{ SolrClient, SolrQuery }
+import org.apache.solr.common.SolrInputDocument
 import org.apache.solr.common.util.{ ContentStreamBase, NamedList }
 
 import scala.language.postfixOps
@@ -36,23 +38,22 @@ trait Solr extends DebugEnhancedLogging {
   def createDoc(item: FileItem, size: Long): Try[FileFeedback] = {
     item.bag.fileUrl(item.path).flatMap { fileUrl =>
       val solrDocId = s"${ item.bag.bagId }/${ item.path }"
-      val solrFields = Seq("file_size" -> size.toString) ++
-        item.bag.solrLiterals ++
-        item.ddm.solrLiterals ++
-        item.solrLiterals
-      val request = new ContentStreamUpdateRequest("/update/extract") {
-        setWaitSearcher(false)
-        setMethod(METHOD.POST)
-        addContentStream(new ContentStreamBase.URLStream(fileUrl))
-        for ((key, value) <- solrFields) {
-          if (value.trim.nonEmpty)
-            setParam(s"literal.easy_$key", value.replaceAll("\\s+", " ").trim)
+      val solrFields = (item.bag.solrLiterals ++ item.ddm.solrLiterals ++ item.solrLiterals :+ "file_size" -> size.toString)
+        .map { case (k, v) => (k, v.replaceAll("\\s+", " ").trim) }
+        .filter { case (_, v) => v.nonEmpty }
+      logger.debug(solrFields
+        .map { case (key, value) => s"$key = $value" }
+        .mkString(s"$solrFields\n\t", "\n\t", "")
+      )
+      submitWithContent(fileUrl, solrDocId, solrFields)
+        .map(_ => FileSubmittedWithContent(solrDocId))
+        .recoverWith { case t =>
+          logger.warn(s"Submission with content of $solrDocId failed with ${ t.getMessage }", t)
+          resubmitMetadata(solrDocId, solrFields).map(_ => FileSubmittedWithJustMetadata(solrDocId))
         }
-        setParam("literal.id", solrDocId)
-      }
-      submitRequest(solrDocId, request)
     }
   }
+
 
   def deleteBag(bagId: String): Try[UpdateResponse] = {
     // no status to check since UpdateResponse is a stub
@@ -66,29 +67,36 @@ trait Solr extends DebugEnhancedLogging {
       .recoverWith { case t => Failure(SolrCommitException(t)) }
   }
 
-  private def submitRequest(solrDocId: String, req: ContentStreamUpdateRequest): Try[FileFeedback] = {
-    logger.debug(req.getParams.getParameterNames.toArray()
-      .map(key => s"$key = ${ req.getParams.getParams(key.toString).toSeq.mkString(", ") }")
-      .mkString("\n\t")
-    )
-    executeUpdate(req)
-      .map(_ => FileSubmittedWithContent(solrDocId))
-      .recoverWith { case t =>
-        logger.warn(s"Submission with content of $solrDocId failed with ${ t.getMessage }", t)
-        req.getContentStreams.clear() // retry with just metadata
-        executeUpdate(req)
-          .map(_ => FileSubmittedWithJustMetadata(solrDocId))
-          .recoverWith {
-            case t2: SolrStatusException => Failure(t2)
-            case t2 => Failure(SolrUpdateException(solrDocId, t2))
-          }
+  private def submitWithContent(fileUrl: URL, solrDocId: String, solrFields: Seq[(FeedBackMessage, FeedBackMessage)]) = {
+    Try(solrClient.request(new ContentStreamUpdateRequest("/update/extract") {
+      setWaitSearcher(false)
+      setMethod(METHOD.POST)
+      addContentStream(new ContentStreamBase.URLStream(fileUrl))
+      for ((k, v) <- solrFields) {
+        setParam(s"literal.easy_$k", v)
       }
+      setParam("literal.id", solrDocId)
+    })).flatMap(checkSolrStatus)
   }
 
-  private def executeUpdate(req: ContentStreamUpdateRequest): Try[Unit] = {
-    Try(solrClient.request(req))
-      .flatMap(checkSolrStatus)
+  private def resubmitMetadata(solrDocId: String, solrFields: Seq[(FeedBackMessage, FeedBackMessage)]) = {
+    Try(solrClient.add(new SolrInputDocument() {
+      solrFields
+        .withFilter(_._1 == "easy_dataset_store_id")
+        .foreach { case (k, v) =>
+          addField(s"easy_$k", v)
+        }
+      addField("id", solrDocId)
+    })).map(_.getStatus match {
+      case 0 => // no response header
+      case HttpStatus.SC_OK =>
+      case status => throw new Exception(s"Resubmit $solrDocId returned status $status")
+    })
+  }.recoverWith {
+    case t2: SolrStatusException => Failure(t2)
+    case t2 => Failure(SolrUpdateException(solrDocId, t2))
   }
+
 
   private def createDeleteQuery(bagId: String) = {
     new SolrQuery {

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Vault.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Vault.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.solr4files.components
 
-import java.net.{ URI, URL }
+import java.net.{ URI, URL, URLEncoder }
 import java.nio.file.Paths
 
 import nl.knaw.dans.easy.solr4files._
@@ -46,6 +46,7 @@ trait Vault extends DebugEnhancedLogging {
   }
 
   def fileURL(storeName: String, bagId: String, file: String): Try[URL] = Try {
-    vaultBaseUri.resolve(s"stores/$storeName/bags/$bagId/$file").toURL
+    val f = URLEncoder.encode(file,"UTF8")
+    vaultBaseUri.resolve(s"stores/$storeName/bags/$bagId/$f").toURL
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
@@ -21,6 +21,7 @@ import java.net.{ URL, URLDecoder }
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.io.FileUtils.readFileToString
+import org.apache.solr.client.solrj.response.UpdateResponse
 import org.apache.solr.common.util.NamedList
 
 import scala.annotation.tailrec
@@ -42,8 +43,11 @@ package object solr4files extends DebugEnhancedLogging {
   case class SolrStatusException(namedList: NamedList[AnyRef])
     extends Exception(s"solr update returned: ${ namedList.asShallowMap().values().toArray().mkString }")
 
-  case class SolrDeleteException(bagId: String, cause: Throwable)
-    extends Exception(s"solr delete of bag $bagId failed with ${ cause.getMessage }", cause)
+  case class SolrUpdateStatusException(msg: String, response: UpdateResponse)
+    extends Exception(s"$msg ${response.getStatus}")
+
+  case class SolrDeleteException(query: String, cause: Throwable)
+    extends Exception(s"solr delete [$query] failed with ${ cause.getMessage }", cause)
 
   case class SolrUpdateException(solrId: String, cause: Throwable)
     extends Exception(s"solr update of file $solrId failed with ${ cause.getMessage }", cause)

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
@@ -21,7 +21,6 @@ import java.net.{ URL, URLDecoder }
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.io.FileUtils.readFileToString
-import org.apache.solr.client.solrj.response.UpdateResponse
 import org.apache.solr.common.util.NamedList
 
 import scala.annotation.tailrec
@@ -41,10 +40,7 @@ package object solr4files extends DebugEnhancedLogging {
     extends Exception(s"$msg - ${ response.statusLine }, details: ${ response.body }")
 
   case class SolrStatusException(namedList: NamedList[AnyRef])
-    extends Exception(s"solr update returned: ${ namedList.asShallowMap().values().toArray().mkString }")
-
-  case class SolrUpdateStatusException(msg: String, response: UpdateResponse)
-    extends Exception(s"$msg ${response.getStatus}")
+    extends Exception(s"solr returned: ${ namedList.asShallowMap().values().toArray().mkString }")
 
   case class SolrDeleteException(query: String, cause: Throwable)
     extends Exception(s"solr delete [$query] failed with ${ cause.getMessage }", cause)
@@ -91,7 +87,7 @@ package object solr4files extends DebugEnhancedLogging {
   case class BagSubmitted(override val msg: String, results: Seq[FileFeedback]) extends Feedback(msg) {
     override def toString: String = {
       val xs = results.groupBy(_.getClass.getSimpleName)
-      s"Bag $msg: ${ xs.keySet.map(className => s"${ xs(className).size } times $className").mkString(", ")}"
+      s"Bag $msg: ${ xs.keySet.map(className => s"${ xs(className).size } times $className").mkString(", ") }"
     }
   }
 

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -2,4 +2,4 @@ default.bag-store=easy
 
 # terminating slashes are required
 vault.url=http://deasy.dans.knaw.nl:20110/
-solr.url=http://deasy.dans.knaw.nl:8983/solr/easyfiles/
+solr.url=http://deasy.dans.knaw.nl:8983/solr/fileitems/

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/ApplicationWiringSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/ApplicationWiringSpec.scala
@@ -22,6 +22,7 @@ import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.solr.client.solrj.request.ContentStreamUpdateRequest
 import org.apache.solr.client.solrj.response.UpdateResponse
 import org.apache.solr.client.solrj.{ SolrClient, SolrRequest, SolrResponse }
+import org.apache.solr.common.SolrInputDocument
 import org.apache.solr.common.util.NamedList
 
 import scala.collection.JavaConverters._
@@ -33,12 +34,16 @@ class ApplicationWiringSpec extends TestSupportFixture {
   private val uuid = "9da0541a-d2c8-432e-8129-979a9830b427"
 
   private class MockedAndStubbedWiring extends ApplicationWiring(createConfig("vault")) {
-    override lazy val solrClient = new SolrClient() {
+    override lazy val solrClient: SolrClient = new SolrClient() {
       // can't use mock because SolrClient has a final method, now we can't count the actual calls
 
       override def deleteByQuery(q: String): UpdateResponse = new UpdateResponse
 
       override def commit(): UpdateResponse = new UpdateResponse
+
+      override def  add(doc: SolrInputDocument): UpdateResponse = new UpdateResponse {
+        override def getStatus = 200
+      }
 
       override def close(): Unit = ()
 

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/ApplicationWiringSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/ApplicationWiringSpec.scala
@@ -75,9 +75,9 @@ class ApplicationWiringSpec extends TestSupportFixture {
   }
 
   "delete" should "call the stubbed solrClient.deleteByQuery" in {
-    val result = new MockedAndStubbedWiring().delete(uuid)
+    val result = new MockedAndStubbedWiring().delete("*:*")
     inside(result) { case Success(msg) =>
-      msg shouldBe s"Deleted file documents for bag $uuid"
+      msg shouldBe s"Deleted documents with query *:*"
     }
   }
 


### PR DESCRIPTION
#Fixes EASY-1320

#### When applied it will

* work for real PDBS bags
* for a next PR:
  * complex spatial coverage types
  * implementation as a service
  * disable `email_ss`? (or  for [easy-1325] the serach-service)

# please squash

#### Where should the reviewer @DANS-KNAW/easy start?

*


#### How should this be manually tested?

* Deploy [#151] roles on deasy: `easy_solr_search` and `easy_solr_search2`
* In dtap: `scp `YOURID`@teasy.dans.knaw.nl:/tmp/pdbs.tar shared/pdbs.tar` and unpack
* On deasy: 
  * `sudo rmdir /data/bag-stores/pdbs/`
  * `sudo cp -r /vagrant/shared/data/bag-stores/pdbs/ /data/bag-stores/`
* Deploy and run on deasy or use the run scripts of dev-tools to run _with_ deasy.
   The 35 PDBS bags can take more than 8 minutes.
* Examine the result at http://deasy.dans.knaw.nl:8983/solr/#/fileitems/query 
  * [x] we don't worry about `attr_stream_size` null nor `attr_image_size` 0

[EASY-1325]: https://drivenbydata.atlassian.net/browse/EASY-1325
[#151]: https://github.com/DANS-KNAW/easy-dtap/pull/151
[managed schema's]: https://github.com/DANS-KNAW/easy-dtap/blob/6546b1ddeb41732b3b40a45013decef9481f2d6b/provisioning/roles/easy_solr4files_cores_easyfiles/tasks/main.yml#L39-L42
[schema-name]: https://github.com/DANS-KNAW/easy-dtap/blob/6546b1ddeb41732b3b40a45013decef9481f2d6b/provisioning/roles/easy_solr4files_cores_easyfiles/tasks/main.yml#L39-L42


#### Related pull requests on github
repo                       | PR                | remark
-------------------------- | ----------------- | ----
easy-dtap       | [#151] | deploy, attr_ prefix caused by previously wrong schema name
easy-bag-store  | todo | Nice to have: file size in files.xml would eliminate a header request

