### PR TITLE
EASY-1320 commands made available as http request

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SYNOPSIS
 
 ### HTTP service
 
-When started with the sub-command `run-service` an HTTP API becomes available summarized in the following table.
+When started with the sub-command `run-service` a REST API becomes available summarized in the following table.
 "Method" refers to the HTTP method used in the request. "Path" is the path pattern used. 
 Placeholders for variables start with a colon, optional parts are enclosed in square brackets.
 

--- a/README.md
+++ b/README.md
@@ -22,18 +22,20 @@ SYNOPSIS
 ### HTTP service
 
 When started with the sub-command `run-service` an HTTP API becomes available summarized in the following table.
-"Method" refers to the HTTP method used in the request. "Path" is the path pattern used.
-In a path pattern `*` refers to any completion of the path, and placeholders for variables start with a colon.
-Optional parts are enclosed in square brackets, a pipe symbol denotes alternatives and parentheses are used to group those alternatives.
+"Method" refers to the HTTP method used in the request. "Path" is the path pattern used. 
+Placeholders for variables start with a colon, optional parts are enclosed in square brackets.
 
-Method   | Path                             |Action
----------|----------------------------------|------------------------------------
-`GET`    | `/fileindex`                     | Return a simple message to indicate that the service is up: "EASY File index is running."
-`POST`   | `/fileindex/init[/:store]`       | Index all bag stores or just one. Eventual obsolete items are cleared.
-`POST`   | `/fileindex/update/:store/:uuid` | Index all files of one bag. Eventual obsolete file items are cleared.
-`DELETE` | `/fileindex/:store[/:uuid]`      | Remove all items or the items of a store or bag.
-`DELETE` | `/fileindex?q=*`                 | Remove the items matching the specified solr query.
+Method   | Path                             | Args |Action
+---------|----------------------------------|------|------------------------------------
+`GET`    | `/fileindex`                     |      | Return a simple message to indicate that the service is up: "EASY File index is running."
+`POST`   | `/fileindex/init[/:store]`       |      | Index all bag stores or just one. Eventual obsolete items are cleared.
+`POST`   | `/fileindex/update/:store/:uuid` |      | Index all files of one bag. Eventual obsolete file items are cleared.
+`DELETE` | `/fileindex/:store[/:uuid]`      |      | Remove all items or the items of a store or bag.
+`DELETE` | `/fileindex/`                    | q    | Remove the items matching the mandatory solr query.
 
+The following example would delete a bag
+
+    http://easy.dans.knaw.nl/fileindex/?q=easy_dataset_id:ef425828-e4ae-4d58-bf6a-c89cd46df61c
 
 DESCRIPTION
 -----------

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ When started with the sub-command `run-service` an HTTP API becomes available su
 In a path pattern `*` refers to any completion of the path, and placeholders for variables start with a colon.
 Optional parts are enclosed in square brackets, a pipe symbol denotes alternatives and parentheses are used to group those alternatives.
 
-Method   | Path                                |Action
----------|-------------------------------------|------------------------------------
-`GET`    | `/fileindex`                        | Return a simple message to indicate that the service is up: "EASY File index is running."
-`POST`   | `/fileindex/init[/:store]`          | Index all bag stores or just one. Eventual obsolete items are cleared.
-`POST`   | `/fileindex/update/:store[/:uuid]`  | Index all files of one bag. Eventual obsolete file items are cleared.
-`DELETE` | `/fileindex/:store[/:uuid]`         | Remove all items or the items of a store or bag.
-`DELETE` | `/fileindex?q=*`                    | Remove the items matching the specified solr query.
+Method   | Path                             |Action
+---------|----------------------------------|------------------------------------
+`GET`    | `/fileindex`                     | Return a simple message to indicate that the service is up: "EASY File index is running."
+`POST`   | `/fileindex/init[/:store]`       | Index all bag stores or just one. Eventual obsolete items are cleared.
+`POST`   | `/fileindex/update/:store/:uuid` | Index all files of one bag. Eventual obsolete file items are cleared.
+`DELETE` | `/fileindex/:store[/:uuid]`      | Remove all items or the items of a store or bag.
+`DELETE` | `/fileindex?q=*`                 | Remove the items matching the specified solr query.
 
 
 DESCRIPTION

--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ SYNOPSIS
       a folder in a bag:     'id:ef425828-e4ae-4d58-bf6a-c89cd46df61c/data/files/Documents/*'
 
 
+### HTTP service
+
+When started with the sub-command `run-service` an HTTP API becomes available summarized in the following table.
+"Method" refers to the HTTP method used in the request. "Path" is the path pattern used.
+In a path pattern `*` refers to any completion of the path, and placeholders for variables start with a colon.
+Optional parts are enclosed in square brackets, a pipe symbol denotes alternatives and parentheses are used to group those alternatives.
+
+Method   | Path                                |Action
+---------|-------------------------------------|------------------------------------
+`GET`    | `/fileindex`                        | Return a simple message to indicate that the service is up: "EASY File index is running."
+`POST`   | `/fileindex/init[/:store]`          | Index all bag stores or just one. Eventual obsolete items are cleared.
+`POST`   | `/fileindex/update/:store[/:uuid]`  | Index all files of one bag. Eventual obsolete file items are cleared.
+`DELETE` | `/fileindex/:store[/:uuid]`         | Remove all items or the items of a store or bag.
+`DELETE` | `/fileindex?q=*`                    | Remove the items matching the specified solr query.
+
+
 DESCRIPTION
 -----------
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,12 @@
             <artifactId>scalatra_2.11</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.scalatra</groupId>
+            <artifactId>scalatra-scalatest_2.11</artifactId>
+            <version>2.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>

--- a/src/main/ansible/requirements.yml
+++ b/src/main/ansible/requirements.yml
@@ -15,7 +15,7 @@
 #
 
 - src: https://github.com/DANS-KNAW/dans.local-yum-repo
-  version: v3.1.0
+  version: v3.1.1
 - src: https://github.com/DANS-KNAW/dans.local-test-vm-base
   version: v2.1.0
 - src: https://github.com/DANS-KNAW/dans.solr

--- a/src/main/ansible/vagrant.yml
+++ b/src/main/ansible/vagrant.yml
@@ -61,18 +61,27 @@
     register: bag_dir_stat
 
   - name: Copy test-bags to server
-    copy:
+    copy: # for now we have just one test bag, otherwise copy pdbs/bags into pdbs/ab and rename it
       src: "../../test/resources/vault/stores/pdbs/bags/9da0541a-d2c8-432e-8129-979a9830b427"
       dest: "{{ stores_dir }}/pdbs/ab/123456789012345678901234567890"
       mode: "0775"
       directory_mode: "0775"
-    # TODO skip all git-ignored files, not just hidden files in the bags folder
-    # workaround for now: just the one bag we have at the moment
     when: "bag_dir_stat.stat.exists == False"
-    # TODO add test bag with:
-    #  a file with spaces and other special characters in its name
-    #  an image with dates that failed with https://github.com/DANS-KNAW/easy-dtap/pull/131
-    #  a pakbon and pdf with metadata that gets indexed as email_ss
+
+  - name: Find hidden files in or between test bags
+    find:
+      paths: "{{ stores_dir }}"
+      patterns: ".DS_Store"
+      hidden: "yes"
+      recurse: "yes"
+    register: hidden_files
+
+  - name: Remove hidden files from test bags
+    file:
+      path: "{{ item.path }}"
+      state: "absent"
+    with_items: "{{ hidden_files.files }}"
+
 
   - service:
       name: "easy-bag-store"

--- a/src/main/ansible/vagrant.yml
+++ b/src/main/ansible/vagrant.yml
@@ -62,10 +62,12 @@
 
   - name: Copy test-bags to server
     copy:
-      src: "../../test/resources/vault/stores/pdbs/bags/"
+      src: "../../test/resources/vault/stores/pdbs/bags/9da0541a-d2c8-432e-8129-979a9830b427"
       dest: "{{ stores_dir }}/pdbs/ab/123456789012345678901234567890"
       mode: "0775"
       directory_mode: "0775"
+    # TODO skip all git-ignored files, not just hidden files in the bags folder
+    # workaround for now: just the one bag we have at the moment
     when: "bag_dir_stat.stat.exists == False"
     # TODO add test bag with:
     #  a file with spaces and other special characters in its name
@@ -125,13 +127,12 @@
 - hosts: "test"
   become: yes
   tasks:
+    - name: Installing package
+      yum:
+        name: dans.knaw.nl-easy-update-solr4files-index
+        state: latest
 
-  - name: Installing update-solr4files-index package
-    yum:
-      name: "dans.knaw.nl-easy-update-solr4files-index"
-      state: latest
-
-#TODO  - service:
-#      name: "easy-update-solr4files-index"
-#      state: restarted
-#      enabled: yes
+    - service:
+        name: easy-update-solr4files-index
+        state: started
+        enabled: yes

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -1,4 +1,5 @@
 default.bag-store=pdbs
+solr4files.daemon.http.port=20150
 
 # terminating slashes are required
 vault.url=http://localhost:20110/

--- a/src/main/assembly/dist/cfg/logback-service.xml
+++ b/src/main/assembly/dist/cfg/logback-service.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration scan="true" scanPeriod="1 minute">
+    <appender name="FILE"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/var/opt/dans.knaw.nl/log/easy-update-solr4files-index/easy-update-solr4files-index.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/var/opt/dans.knaw.nl/log/easy-update-solr4files-index/easy-update-solr4files-index.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>[%date{ISO8601}] %-5level %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="warn">
+        <appender-ref ref="FILE"/>
+    </root>
+    <logger name="nl.knaw.dans.easy" level="info"/>
+</configuration>

--- a/src/main/assembly/dist/install/easy-update-solr4files-index-initd.sh
+++ b/src/main/assembly/dist/install/easy-update-solr4files-index-initd.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#  /etc/init.d/easy-update-solr4files-index
+# chkconfig: 2345 92 58
+
+### BEGIN INIT INFO
+# Provides:          easy-update-solr4files-index
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Short-Description: Starts the easy-update-solr4files-index service
+# Description:       This file is used to start the daemon
+#                    and should be placed in /etc/init.d
+### END INIT INFO
+
+NAME="easy-update-solr4files-index"
+EXEC="/usr/bin/jsvc"
+APPHOME="/opt/dans.knaw.nl/$NAME"
+JAVA_HOME="/usr/lib/jvm/jre"
+CLASSPATH="$APPHOME/bin/$NAME.jar"
+CLASS="nl.knaw.dans.easy.solr4files.ServiceStarter"
+ARGS=""
+USER="$NAME"
+PID="/var/run/$NAME.pid"
+OUTFILE="/var/opt/dans.knaw.nl/log/$NAME/$NAME.out"
+ERRFILE="/var/opt/dans.knaw.nl/log/$NAME/$NAME.err"
+WAIT_TIME=60
+
+jsvc_exec()
+{
+    cd $APPHOME
+    LOGBACK_CFG=/etc/opt/dans.knaw.nl/$NAME/logback-service.xml
+    if [ ! -f $LOGBACK_CFG ]; then
+        LOGBACK_CFG=$APPHOME/cfg/logback-service.xml
+    fi
+
+    # Set LC_ALL to a locale with UTF-8 to make sure non-ASCII file names are written correctly to the file system (see: EASY-1254).
+    LC_ALL=en_US.UTF-8 \
+    $EXEC -home $JAVA_HOME -cp $CLASSPATH -user $USER -outfile $OUTFILE -errfile $ERRFILE -pidfile $PID -wait $WAIT_TIME \
+          -Dapp.home=$APPHOME \
+          -Dlogback.configurationFile=$LOGBACK_CFG $1 $CLASS $ARGS
+}
+
+start_jsvc_exec()
+{
+    jsvc_exec
+    if [[ $? == 0 ]]; then # start is successful
+        echo "$NAME has started."
+    else
+        echo "$NAME did not start successfully (exit code: $?)."
+    fi
+}
+
+stop_jsvc_exec()
+{
+    jsvc_exec "-stop"
+    if [[ $? == 0 ]]; then # stop is successful
+        echo "$NAME has stopped."
+    else
+        echo "$NAME did not stop successfully (exit code: $?)".
+    fi
+}
+
+restart_jsvc_exec()
+{
+    echo "Restarting $NAME ..."
+    jsvc_exec "-stop"
+    if [[ $? == 0 ]]; then # stop is successful
+        echo "$NAME has stopped, starting again ..."
+        jsvc_exec
+        if [[ $? == 0 ]]; then # start is successful
+            echo "$NAME has restarted."
+        else
+            echo "$NAME did not start successfully (exit code: $?)."
+        fi
+    else
+        echo "$NAME did not stop successfully (exit code: $?)."
+    fi
+}
+
+case "$1" in
+    start)
+        if [ -f "$PID" ]; then # service is running
+            echo "$NAME is already running, no action taken."
+            exit 1
+        else
+            echo "Starting $NAME ..."
+            start_jsvc_exec
+        fi
+    ;;
+    stop)
+        if [ -f "$PID" ]; then # service is running
+            echo "Stopping $NAME ..."
+            stop_jsvc_exec
+        else
+            echo "$NAME is not running, no action taken."
+            exit 1
+        fi
+    ;;
+    restart)
+        if [ -f "$PID" ]; then # service is running
+            restart_jsvc_exec
+        else
+            echo "$NAME is not running, just starting ..."
+            start_jsvc_exec
+        fi
+    ;;
+    status)
+        if [ -f "$PID" ]; then # if service is running
+            echo "$NAME (pid `cat $PID`) is running."
+        else
+            echo "$NAME is stopped."
+        fi
+    ;;
+    *)
+        echo "Usage: sudo service $NAME {start|stop|restart|status}" >&2
+        exit 3
+    ;;
+esac

--- a/src/main/assembly/dist/install/easy-update-solr4files-index.service
+++ b/src/main/assembly/dist/install/easy-update-solr4files-index.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=EASY SOLR for Files index service
+
+[Service]
+ExecStart=/bin/java \
+ -Dlogback.configurationFile=/etc/opt/dans.knaw.nl/easy-update-solr4files-index/logback-service.xml \
+ -Dapp.home=/opt/dans.knaw.nl/easy-update-solr4files-index \
+ -jar /opt/dans.knaw.nl/easy-update-solr4files-index/bin/easy-update-solr4files-index.jar run-service
+
+User=easy-update-solr4files-index
+Group=easy-update-solr4files-index
+
+[Install]
+WantedBy=multi-user.target

--- a/src/main/assembly/dist/install/override.conf
+++ b/src/main/assembly/dist/install/override.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment="LC_ALL=en_US.UTF-8"

--- a/src/main/rpm/1-pre-install.sh
+++ b/src/main/rpm/1-pre-install.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#include <service.sh>
+
+NUMBER_OF_INSTALLATIONS=$1
+MODULE_NAME=easy-update-solr4files-index
+PHASE="PRE-INSTALL"
+
+echo "$PHASE: START (Number of current installations: $NUMBER_OF_INSTALLATIONS)"
+service_stop $MODULE_NAME $NUMBER_OF_INSTALLATIONS
+service_create_module_user $MODULE_NAME
+echo "$PHASE: DONE"

--- a/src/main/rpm/2-post-install.sh
+++ b/src/main/rpm/2-post-install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#include <service.sh>
+
+NUMBER_OF_INSTALLATIONS=$1
+MODULE_NAME=easy-update-solr4files-index
+INSTALL_DIR=/opt/dans.knaw.nl/$MODULE_NAME
+PHASE="POST-INSTALL"
+
+echo "$PHASE: START (Number of current installations: $NUMBER_OF_INSTALLATIONS)"
+service_install_initd_service_script "$INSTALL_DIR/install/$MODULE_NAME-initd.sh" $MODULE_NAME
+service_install_systemd_unit "$INSTALL_DIR/install/$MODULE_NAME.service" $MODULE_NAME "$INSTALL_DIR/install/override.conf"
+service_create_log_directory $MODULE_NAME
+echo "$PHASE: DONE"

--- a/src/main/rpm/4-post-remove.sh
+++ b/src/main/rpm/4-post-remove.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#include <service.sh>
+
+NUMBER_OF_INSTALLATIONS=$1
+MODULE_NAME=easy-update-solr4files-index
+PHASE="POST-REMOVE"
+
+echo "$PHASE: START (Number of current installations: $NUMBER_OF_INSTALLATIONS)"
+service_remove_initd_service_script $MODULE_NAME $NUMBER_OF_INSTALLATIONS
+service_remove_systemd_unit $MODULE_NAME $NUMBER_OF_INSTALLATIONS
+echo "$PHASE: DONE"

--- a/src/main/rpm/5-post-trans.sh
+++ b/src/main/rpm/5-post-trans.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+#include <service.sh>
+
+MODULE_NAME=easy-update-solr4files-index
+PHASE="POST-TRANS"
+
+echo "$PHASE: START"
+service_restart $MODULE_NAME
+echo "$PHASE: DONE"

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
@@ -53,7 +53,7 @@ class ApplicationWiring(configuration: Configuration)
       ddmXML <- bag.loadDDM
       ddm = new DDM(ddmXML)
       filesXML <- bag.loadFilesXML
-      _ <- deleteDocuments(s"id:${bag.bagId}*")
+      _ <- deleteDocuments(s"id:${ bag.bagId }*")
       feedbackMessage <- updateFiles(bag, ddm, filesXML)
       _ <- commit()
     } yield feedbackMessage

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.solr4files
 
 import java.net.{ URI, URL }
+import java.util.UUID
 
 import nl.knaw.dans.easy.solr4files.components._
 import nl.knaw.dans.lib.error._
@@ -46,7 +47,7 @@ class ApplicationWiring(configuration: Configuration)
       .flatMap(updateBags(storeName, _))
   }
 
-  def update(storeName: String, bagId: String): Try[BagSubmitted] = {
+  def update(storeName: String, bagId: UUID): Try[BagSubmitted] = {
     val bag = Bag(storeName, bagId, this)
     for {
       ddmXML <- bag.loadDDM
@@ -98,7 +99,7 @@ class ApplicationWiring(configuration: Configuration)
    * The number of files submitted with or without content per bag are logged as info
    * if and when another bag in the same store failed.
    */
-  private def updateBags(storeName: String, bagIds: Seq[String]): Try[StoreSubmitted] = {
+  private def updateBags(storeName: String, bagIds: Seq[UUID]): Try[StoreSubmitted] = {
     bagIds
       .toStream
       .map(update(storeName, _))
@@ -120,6 +121,6 @@ class ApplicationWiring(configuration: Configuration)
       .map(f => createDoc(f, getSize(f.bag.storeName, f.bag.bagId, f.path)))
       .takeUntilFailure
       .doIfFailure { case MixedResultsException(results: Seq[_], _) => results.foreach(fb => logger.info(fb.toString)) }
-      .map(results => BagSubmitted(bag.bagId, results))
+      .map(results => BagSubmitted(bag.bagId.toString, results))
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/CommandLineOptions.scala
@@ -15,10 +15,11 @@
  */
 package nl.knaw.dans.easy.solr4files
 
-import org.rogach.scallop.{ ScallopConf, ScallopOption, Subcommand }
+import java.util.UUID
+
+import org.rogach.scallop.{ ScallopConf, ScallopOption, Subcommand, ValueConverter, singleArgConverter }
 
 class CommandLineOptions(args: Array[String], configuration: Configuration) extends ScallopConf(args) {
-  type UUID = String
   type StoreName = String
 
   appendDefaultToDescription = true
@@ -56,6 +57,12 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
 
   private val defaultBagStore = Some(configuration.properties.getString("default.bag-store", "MISSING_BAG_STORE"))
 
+  private def bagId: ValueConverter[UUID] = {
+    singleArgConverter {
+      case s => UUID.fromString(s)
+    }
+  }
+
   val update = new Subcommand("update") {
     descr("Update accessible files of a bag in the SOLR index")
     val bagStore: ScallopOption[StoreName] = opt[StoreName](
@@ -63,12 +70,12 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
       default = defaultBagStore,
       short = 's',
       descr = "Name of the bag store")
-    val bagUuid: ScallopOption[UUID] = trailArg(name = "bag-uuid", required = true)
+    val bagUuid: ScallopOption[UUID] = trailArg[UUID](name = "bag-uuid", required = true)(bagId)
     footer(SUBCOMMAND_SEPARATOR)
   }
   val delete = new Subcommand("delete") {
     descr("Delete documents from the SOLR index")
-    val query: ScallopOption[UUID] = trailArg(name = "solr-query", required = true)
+    val query: ScallopOption[String] = trailArg[String](name = "solr-query", required = true)
     footer(SUBCOMMAND_SEPARATOR)
   }
   val init = new Subcommand("init") {

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/CommandLineOptions.scala
@@ -57,7 +57,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
 
   private val defaultBagStore = Some(configuration.properties.getString("default.bag-store", "MISSING_BAG_STORE"))
 
-  private def bagId: ValueConverter[UUID] = {
+  private implicit def bagId: ValueConverter[UUID] = {
     singleArgConverter {
       case s => UUID.fromString(s)
     }
@@ -70,7 +70,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
       default = defaultBagStore,
       short = 's',
       descr = "Name of the bag store")
-    val bagUuid: ScallopOption[UUID] = trailArg[UUID](name = "bag-uuid", required = true)(bagId)
+    val bagUuid: ScallopOption[UUID] = trailArg[UUID](name = "bag-uuid", required = true)
     footer(SUBCOMMAND_SEPARATOR)
   }
   val delete = new Subcommand("delete") {

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexApp.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy.solr4files
 
+import java.util.UUID
+
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 import scala.util.{ Success, Try }
@@ -26,7 +28,7 @@ class EasyUpdateSolr4filesIndexApp(wiring: ApplicationWiring) extends AutoClosea
 
   def initSingleStore(storeName: String): Try[String] = wiring.initSingleStore(storeName).map(_.toString)
 
-  def update(storeName: String, bagId: String): Try[String] = wiring.update(storeName, bagId).map(_.toString)
+  def update(storeName: String, bagId: UUID): Try[String] = wiring.update(storeName, bagId).map(_.toString)
 
   def delete(query: String): Try[String] = wiring.delete(query)
 

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexService.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexService.scala
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.solr4files
+
+import javax.servlet.ServletContext
+
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.servlet.ServletContextHandler
+import org.scalatra.LifeCycle
+import org.scalatra.servlet.ScalatraListener
+
+import scala.util.Try
+
+class EasyUpdateSolr4filesIndexService(val serverPort: Int, app: EasyUpdateSolr4filesIndexApp) extends DebugEnhancedLogging {
+
+  private val server = new Server(serverPort) {
+    this.setHandler(new ServletContextHandler(ServletContextHandler.NO_SESSIONS) {
+      this.addEventListener(new ScalatraListener() {
+        override def probeForCycleClass(classLoader: ClassLoader): (String, LifeCycle) = {
+          ("Solr4files-lifecycle", new LifeCycle {
+            override def init(context: ServletContext): Unit = {
+              context.mount(new EasyUpdateSolr4filesIndexServlet(app), "/fileindex")
+            }
+          })
+        }
+      })
+    })
+  }
+
+  logger.info(s"HTTP port is $serverPort")
+
+  def start(): Try[Unit] = Try {
+    logger.info("Starting service...")
+    server.start()
+  }
+
+  def stop(): Try[Unit] = Try {
+    logger.info("Stopping service...")
+    server.stop()
+  }
+
+  def destroy(): Try[Unit] = Try {
+    server.destroy()
+    app.close()
+    logger.info("Service stopped.")
+  }
+}

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexServlet.scala
@@ -45,7 +45,9 @@ class EasyUpdateSolr4filesIndexServlet(app: EasyUpdateSolr4filesIndexApp) extend
         case MixedResultsException(_, HttpStatusException(message, r: HttpResponse[String])) if r.code == SC_NOT_FOUND => NotFound(msgPrefix + message)
         case MixedResultsException(_, HttpStatusException(message, r: HttpResponse[String])) if r.code == SC_SERVICE_UNAVAILABLE => ServiceUnavailable(msgPrefix + message)
         case MixedResultsException(_, HttpStatusException(message, r: HttpResponse[String])) if r.code == SC_REQUEST_TIMEOUT => RequestTimeout(msgPrefix + message)
-        case e => InternalServerError(e.getMessage) // TODO no or neutral message for to be implemented public search
+        case e =>
+          e.printStackTrace()
+          InternalServerError(e.getMessage) // TODO no or neutral message for to be implemented public search
       }
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexServlet.scala
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.solr4files
+
+import nl.knaw.dans.lib.error._
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.scalatra._
+
+import scala.util.Try
+
+class EasyUpdateSolr4filesIndexServlet(app: EasyUpdateSolr4filesIndexApp) extends ScalatraServlet with DebugEnhancedLogging {
+  logger.info("File index Servlet running...")
+
+  get("/") {
+    contentType = "text/plain"
+    Ok("EASY File Index is running.")
+  }
+
+  private def respond(result: Try[String]): ActionResult = {
+    result.map(Ok(_))
+      .doIfFailure { case e => logger.error(e.getMessage, e) }
+      .getOrRecover(_ => InternalServerError())
+  }
+
+  post("/update/:store/:uuid") {
+    respond(app.update(params("store"),params("uuid")))
+  }
+
+  post("/init") {
+    params.get("store")
+      .map (app.initSingleStore)
+      .getOrElse(respond(app.initAllStores()))
+  }
+
+  delete("/:store/:uuid") {
+    respond(app.delete(s"easy_dataset_id:${params("uuid")}"))
+  }
+
+  delete("/:store") {
+    respond(app.delete(s"easy_dataset_store_id:${params("store")}"))
+  }
+
+  delete("/") {
+    params.get("q")
+      .map (app.delete)
+      .getOrElse(BadRequest(s"delete requires param 'q': a solr query"))
+  }
+}

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexServlet.scala
@@ -15,15 +15,12 @@
  */
 package nl.knaw.dans.easy.solr4files
 
-import java.lang.Exception
-
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.http.HttpStatus._
 import org.scalatra._
 
 import scala.util.Try
-import scala.util.control.Exception
 import scalaj.http.HttpResponse
 
 class EasyUpdateSolr4filesIndexServlet(app: EasyUpdateSolr4filesIndexApp) extends ScalatraServlet with DebugEnhancedLogging {
@@ -55,9 +52,11 @@ class EasyUpdateSolr4filesIndexServlet(app: EasyUpdateSolr4filesIndexApp) extend
   }
 
   post("/init") {
-    params.get("store")
-      .map(app.initSingleStore)
-      .getOrElse(respond(app.initAllStores()))
+    respond(app.initAllStores())
+  }
+
+  post("/init/:store") {
+    respond(app.initSingleStore(params("store")))
   }
 
   delete("/:store/:uuid") {

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexServlet.scala
@@ -22,7 +22,7 @@ import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.http.HttpStatus._
 import org.scalatra._
 
-import scala.util.{ Failure, Try }
+import scala.util.Try
 import scalaj.http.HttpResponse
 
 class EasyUpdateSolr4filesIndexServlet(app: EasyUpdateSolr4filesIndexApp) extends ScalatraServlet with DebugEnhancedLogging {
@@ -45,9 +45,7 @@ class EasyUpdateSolr4filesIndexServlet(app: EasyUpdateSolr4filesIndexApp) extend
         case MixedResultsException(_, HttpStatusException(message, r: HttpResponse[String])) if r.code == SC_NOT_FOUND => NotFound(msgPrefix + message)
         case MixedResultsException(_, HttpStatusException(message, r: HttpResponse[String])) if r.code == SC_SERVICE_UNAVAILABLE => ServiceUnavailable(msgPrefix + message)
         case MixedResultsException(_, HttpStatusException(message, r: HttpResponse[String])) if r.code == SC_REQUEST_TIMEOUT => RequestTimeout(msgPrefix + message)
-        case e =>
-          e.printStackTrace()
-          InternalServerError(e.getMessage) // TODO no or neutral message for to be implemented public search
+        case e => InternalServerError(e.getMessage) // TODO no or neutral message for to be implemented public search
       }
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexServlet.scala
@@ -49,7 +49,7 @@ class EasyUpdateSolr4filesIndexServlet(app: EasyUpdateSolr4filesIndexApp) extend
       }
   }
 
-  private def triedUuid = {
+  private def getUUID = {
     Try { UUID.fromString(params("uuid")) }
   }
 
@@ -58,7 +58,7 @@ class EasyUpdateSolr4filesIndexServlet(app: EasyUpdateSolr4filesIndexApp) extend
   }
 
   post("/update/:store/:uuid") {
-    triedUuid
+    getUUID
       .map(uuid => respond(app.update(params("store"), uuid)))
       .getOrRecover(badUuid)
   }
@@ -72,7 +72,7 @@ class EasyUpdateSolr4filesIndexServlet(app: EasyUpdateSolr4filesIndexApp) extend
   }
 
   delete("/:store/:uuid") {
-    triedUuid
+    getUUID
       .map(uuid => respond(app.delete(s"easy_dataset_id:$uuid")))
       .getOrRecover(badUuid)
   }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/EasyUpdateSolr4filesIndexServlet.scala
@@ -32,7 +32,7 @@ class EasyUpdateSolr4filesIndexServlet(app: EasyUpdateSolr4filesIndexApp) extend
   }
 
   private def respond(result: Try[String]): ActionResult = {
-    val msg = "Log files should show which actions succeeded. Finally failed with: "
+    val msgPrefix = "Log files should show which actions succeeded. Finally failed with: "
     result.map(Ok(_))
       .doIfFailure { case e => logger.error(e.getMessage, e) }
       .getOrRecover {
@@ -40,9 +40,9 @@ class EasyUpdateSolr4filesIndexServlet(app: EasyUpdateSolr4filesIndexApp) extend
         case HttpStatusException(message, r: HttpResponse[String]) if r.code == SC_NOT_FOUND => NotFound(message)
         case HttpStatusException(message, r: HttpResponse[String]) if r.code == SC_SERVICE_UNAVAILABLE => ServiceUnavailable(message)
         case HttpStatusException(message, r: HttpResponse[String]) if r.code == SC_REQUEST_TIMEOUT => RequestTimeout(message)
-        case MixedResultsException(_, HttpStatusException(message, r: HttpResponse[String])) if r.code == SC_NOT_FOUND => NotFound(msg + message)
-        case MixedResultsException(_, HttpStatusException(message, r: HttpResponse[String])) if r.code == SC_SERVICE_UNAVAILABLE => ServiceUnavailable(msg + message)
-        case MixedResultsException(_, HttpStatusException(message, r: HttpResponse[String])) if r.code == SC_REQUEST_TIMEOUT => RequestTimeout(msg + message)
+        case MixedResultsException(_, HttpStatusException(message, r: HttpResponse[String])) if r.code == SC_NOT_FOUND => NotFound(msgPrefix + message)
+        case MixedResultsException(_, HttpStatusException(message, r: HttpResponse[String])) if r.code == SC_SERVICE_UNAVAILABLE => ServiceUnavailable(msgPrefix + message)
+        case MixedResultsException(_, HttpStatusException(message, r: HttpResponse[String])) if r.code == SC_REQUEST_TIMEOUT => RequestTimeout(msgPrefix + message)
         case e => InternalServerError(e.getMessage) // TODO no or neutral message for to be implemented public search
       }
   }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/ServiceStarter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/ServiceStarter.scala
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.solr4files
+
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.apache.commons.daemon.{ Daemon, DaemonContext }
+
+class ServiceStarter extends Daemon with DebugEnhancedLogging {
+  var app: EasyUpdateSolr4filesIndexApp = _
+  var service: EasyUpdateSolr4filesIndexService = _
+
+  override def init(context: DaemonContext): Unit = {
+    logger.info("Initializing service...")
+    val configuration = Configuration()
+    app = new EasyUpdateSolr4filesIndexApp(new ApplicationWiring(configuration))
+    service = new EasyUpdateSolr4filesIndexService(configuration.properties.getInt("solr4files.daemon.http.port"), app)
+    logger.info("Service initialized.")
+  }
+
+  override def start(): Unit = {
+    logger.info("Starting service...")
+    app.init()
+      .flatMap(_ => service.start())
+      .unsafeGetOrThrow
+    logger.info("Service started.")
+  }
+
+  override def stop(): Unit = {
+    logger.info("Stopping service...")
+    service.stop().unsafeGetOrThrow
+  }
+
+  override def destroy(): Unit = {
+    service.destroy().unsafeGetOrThrow
+    logger.info("Service stopped.")
+  }
+}

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Bag.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Bag.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.solr4files.components
 
-import java.net.{ URL, URLEncoder }
+import java.net.URL
 import java.util.UUID
 
 import nl.knaw.dans.easy.solr4files.{ FileToShaMap, SolrLiterals, _ }
@@ -48,7 +48,8 @@ case class Bag(storeName: String,
 
   // splits a string on the first sequence of white space after the sha
   // the rest is a path that might contain white space
-  private lazy val regex: Regex = """(\w+)\s+(.*)""".r()
+  private lazy val regex: Regex =
+  """(\w+)\s+(.*)""".r()
 
   private lazy val fileShas: FileToShaMap = {
     // gov.loc.repository.bagit.reader.ManifestReader reads files, we need URL or stream

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Bag.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Bag.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.solr4files.components
 
 import java.net.{ URL, URLEncoder }
+import java.util.UUID
 
 import nl.knaw.dans.easy.solr4files.{ FileToShaMap, SolrLiterals, _ }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
@@ -25,7 +26,7 @@ import scala.util.matching.Regex
 import scala.xml.Elem
 
 case class Bag(storeName: String,
-               bagId: String,
+               bagId: UUID,
                private val vault: Vault
               ) extends DebugEnhancedLogging {
 
@@ -75,6 +76,6 @@ case class Bag(storeName: String,
   val solrLiterals: SolrLiterals = Seq(
     ("dataset_store_id", storeName),
     ("dataset_depositor_id", getDepositor),
-    ("dataset_id", bagId)
+    ("dataset_id", bagId.toString)
   )
 }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Vault.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Vault.scala
@@ -34,7 +34,7 @@ trait Vault extends DebugEnhancedLogging {
   } yield lines.map { line =>
     val trimmed = line.trim.replace("<", "").replace(">", "")
     Paths
-      .get(new URI(trimmed).getPath) // TODO? catch (corrupt bag-store)
+      .get(new URI(trimmed).getPath)
       .getFileName.toString
   }
 
@@ -44,7 +44,7 @@ trait Vault extends DebugEnhancedLogging {
     lines <- storeURI.toURL.readLines
   } yield lines
     .withFilter(_.trim.nonEmpty)
-    .map(str => UUID.fromString(str.trim)) // TODO? catch (corrupt bag-store)
+    .map(str => UUID.fromString(str.trim))
 
   def getSize(storeName: String, bagId: UUID, path: String): Long = {
     fileURL(storeName, bagId, path).map(_.getContentLength).getOrElse(-1L)

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Vault.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Vault.scala
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy.solr4files.components
 
 import java.net.{ URI, URL, URLEncoder }
 import java.nio.file.Paths
+import java.util.UUID
 
 import nl.knaw.dans.easy.solr4files._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
@@ -32,21 +33,25 @@ trait Vault extends DebugEnhancedLogging {
     lines <- uri.toURL.readLines
   } yield lines.map { line =>
     val trimmed = line.trim.replace("<", "").replace(">", "")
-    Paths.get(new URI(trimmed).getPath).getFileName.toString
+    Paths
+      .get(new URI(trimmed).getPath) // TODO? catch (corrupt bag-store)
+      .getFileName.toString
   }
 
-  def getBagIds(storeName: String): Try[Seq[String]] = for {
+  def getBagIds(storeName: String): Try[Seq[UUID]] = for {
   // no state param (in fact no param at all) so we just get the active bags
     storeURI <- Try(vaultBaseUri.resolve(s"stores/$storeName/bags"))
     lines <- storeURI.toURL.readLines
-  } yield lines.withFilter(_.trim.nonEmpty).map(_.trim)
+  } yield lines
+    .withFilter(_.trim.nonEmpty)
+    .map(str => UUID.fromString(str.trim)) // TODO? catch (corrupt bag-store)
 
-  def getSize(storeName: String, bagId: String, path: String): Long = {
+  def getSize(storeName: String, bagId: UUID, path: String): Long = {
     fileURL(storeName, bagId, path).map(_.getContentLength).getOrElse(-1L)
   }
 
-  def fileURL(storeName: String, bagId: String, file: String): Try[URL] = Try {
-    val f = URLEncoder.encode(file,"UTF8")
+  def fileURL(storeName: String, bagId: UUID, file: String): Try[URL] = Try {
+    val f = URLEncoder.encode(file, "UTF8")
     vaultBaseUri.resolve(s"stores/$storeName/bags/$bagId/$f").toURL
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
@@ -150,5 +150,16 @@ package object solr4files extends DebugEnhancedLogging {
     }.doIfFailure { case e => logger.warn(e.getMessage, e) }
       .getOrElse(-1L)
   }
+
+  implicit class TryExtensions2[T](val t: Try[T]) extends AnyVal {
+    // copied from easy-bag-store
+    // TODO candidate for dans-scala-lib
+    def unsafeGetOrThrow: T = {
+      t match {
+        case Success(value) => value
+        case Failure(throwable) => throw throwable
+      }
+    }
+  }
 }
 

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
@@ -42,6 +42,9 @@ package object solr4files extends DebugEnhancedLogging {
   case class SolrStatusException(namedList: NamedList[AnyRef])
     extends Exception(s"solr returned: ${ namedList.asShallowMap().values().toArray().mkString }")
 
+  case class SolrBadRequestException(msg: String, cause: Throwable)
+    extends Exception(msg, cause)
+
   case class SolrDeleteException(query: String, cause: Throwable)
     extends Exception(s"solr delete [$query] failed with ${ cause.getMessage }", cause)
 

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -1,4 +1,5 @@
 default.bag-store=easy
+solr4files.daemon.http.port=20150
 
 # terminating slashes are required
 vault.url=http://deasy.dans.knaw.nl:20110/

--- a/src/test/resources/debug-config/logback-service.xml
+++ b/src/test/resources/debug-config/logback-service.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration scan="true" scanPeriod="1 minute">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%date{ISO8601}] %-5level %msg %n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>data/easy-update-solr4files-index.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>data/easy-update-solr4files-index.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>[%date{ISO8601}] %-5level %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="warn">
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="STDOUT"/>
+    </root>
+    <logger name="nl.knaw.dans.easy" level="trace"/>
+</configuration>

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/ApplicationWiringSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/ApplicationWiringSpec.scala
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy.solr4files
 
 import java.net.URLEncoder
 import java.nio.file.Paths
+import java.util.UUID
 
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.solr.client.solrj.request.ContentStreamUpdateRequest
@@ -31,7 +32,7 @@ import scala.util.{ Failure, Success }
 class ApplicationWiringSpec extends TestSupportFixture {
 
   private val store = "pdbs"
-  private val uuid = "9da0541a-d2c8-432e-8129-979a9830b427"
+  private val uuid = UUID.fromString("9da0541a-d2c8-432e-8129-979a9830b427")
 
   private class MockedAndStubbedWiring extends ApplicationWiring(createConfig("vault")) {
     override lazy val solrClient: SolrClient = new SolrClient() {
@@ -89,7 +90,7 @@ class ApplicationWiringSpec extends TestSupportFixture {
   "initSingleStore" should "call the stubbed ApplicationWiring.update method" in {
     val result = new ApplicationWiring(createConfig("vaultBagIds")) {
       // vaultBagIds/bags can't be a file and directory so we need a stub, a failure demonstrates it's called
-      override def update(store: String, uuid: String) =
+      override def update(store: String, uuid: UUID) =
         Failure(new Exception("stubbed ApplicationWiring.update"))
     }.initSingleStore(store)
 

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/ServletFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/ServletFixture.scala
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/ServletFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/ServletFixture.scala
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.solr4files
+
+import org.eclipse.jetty.server.nio.SelectChannelConnector
+import org.scalatra.test.EmbeddedJettyContainer
+import org.scalatra.test.scalatest.ScalatraSuite
+
+/**
+ * Temporary fixture such that the servlets can be tested with ScalatraSuite.
+ * This Suite relies on Jetty 9.x, while we still require Jetty 8.x
+ * By overriding the two functions below, issues related to these versions are solved.
+ */
+trait ServletFixture extends EmbeddedJettyContainer {
+  this: ScalatraSuite =>
+
+  override def localPort: Option[Int] = server.getConnectors.collectFirst {
+    case x: SelectChannelConnector => x.getLocalPort
+  }
+
+  override def baseUrl: String = {
+    server.getConnectors.collectFirst {
+      case conn: SelectChannelConnector =>
+        val host = Option(conn.getHost).getOrElse("localhost")
+        val port = conn.getLocalPort
+        require(port > 0, "The detected local port is < 1, that's not allowed")
+        "http://%s:%d".format(host, port)
+    }.getOrElse(sys.error("can't calculate base URL: no connector"))
+  }
+}

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
@@ -65,7 +65,7 @@ class SolrErrorHandlingSpec extends TestSupportFixture
 
 
   it should "return the exception bubbling up from solrClient.deleteByQuery" in {
-    delete("/xxx/yyy") {
+    delete("/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
       status shouldBe SC_INTERNAL_SERVER_ERROR // TODO should be bad request
       body shouldBe ""
     }

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.solr4files
+
+import java.net.URLEncoder
+import java.nio.file.Paths
+
+import org.apache.commons.configuration.PropertiesConfiguration
+import org.apache.http.HttpStatus._
+import org.apache.solr.client.solrj.impl.HttpSolrClient
+import org.apache.solr.client.solrj.response.UpdateResponse
+import org.apache.solr.client.solrj.{ SolrClient, SolrRequest, SolrResponse }
+import org.apache.solr.common.SolrInputDocument
+import org.apache.solr.common.util.NamedList
+import org.scalamock.scalatest.MockFactory
+import org.scalatra.test.scalatest.ScalatraSuite
+
+class SolrErrorHandlingSpec extends TestSupportFixture
+  with ServletFixture
+  with ScalatraSuite
+  with MockFactory {
+
+  private val configuration = new Configuration("", new PropertiesConfiguration() {
+    private val vaultPath = URLEncoder.encode(Paths.get(s"src/test/resources/vault/stores/pdbs").toAbsolutePath.toString, "UTF8")
+    addProperty("solr.url", "http://deasy.dans.knaw.nl:8983/solr/easyfiles")
+    addProperty("vault.url", s"file:///$vaultPath/")
+  })
+  private class StubbedWiring extends {} with ApplicationWiring(configuration) {
+    override lazy val solrClient: SolrClient = new SolrClient() {
+      // can't use mock because SolrClient has a final method, now we can't count the actual calls
+
+      override def deleteByQuery(q: String): UpdateResponse = {
+        case class MockedParseException() extends Exception
+        throw new HttpSolrClient.RemoteSolrException("mockedHost", 0, "mocked message", MockedParseException())
+      }
+
+      override def commit(): UpdateResponse =
+        throw new Exception("not expected call")
+
+      override def add(doc: SolrInputDocument): UpdateResponse =
+        throw new Exception("not expected call")
+
+      override def close(): Unit = ()
+
+      override def request(solrRequest: SolrRequest[_ <: SolrResponse], s: String): NamedList[AnyRef] =
+        throw new Exception("not expected call")
+    }
+  }
+
+  private val app = new EasyUpdateSolr4filesIndexApp(new StubbedWiring)
+  addServlet(new EasyUpdateSolr4filesIndexServlet(app), "/*")
+
+
+  it should "return the exception bubbling up from solrClient.deleteByQuery" in {
+    delete("/xxx/yyy") {
+      status shouldBe SC_INTERNAL_SERVER_ERROR // TODO should be bad request
+      body shouldBe ""
+    }
+  }
+}

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
@@ -15,9 +15,6 @@
  */
 package nl.knaw.dans.easy.solr4files
 
-import java.net.URI
-
-import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.http.HttpStatus._
 import org.apache.solr.client.solrj.impl.HttpSolrClient
 import org.apache.solr.client.solrj.response.UpdateResponse
@@ -30,13 +27,7 @@ class SolrErrorHandlingSpec extends TestSupportFixture
   with ServletFixture
   with ScalatraSuite {
 
-  private class StubbedWiring extends {
-    private val vault = mockVault("vault")
-  } with ApplicationWiring(new Configuration("", new PropertiesConfiguration() {
-    addProperty("solr.url", "http://deasy.dans.knaw.nl:8983/solr/easyfiles") // to survive the wiring constructor
-    addProperty("vault.url", vault.vaultBaseUri.toURL.toString)
-  })) {
-    override val vaultBaseUri: URI = vault.vaultBaseUri
+  private class StubbedWiring extends ApplicationWiring(createConfig("vault")) {
     override lazy val solrClient: SolrClient = new SolrClient() {
       // can't use mock because SolrClient has a final method
 

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
@@ -75,7 +75,7 @@ class SolrErrorHandlingSpec extends TestSupportFixture
   "submit" should "return the exception bubbling up from solrClient.request" in {
     post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
       body shouldBe "solr update of file 9da0541a-d2c8-432e-8129-979a9830b427/data/path/to/a/random/video/hubble.mpg failed with mocked add"
-      status shouldBe SC_INTERNAL_SERVER_ERROR // MixedResults(mocked add)
+      status shouldBe SC_INTERNAL_SERVER_ERROR
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
@@ -1,7 +1,11 @@
 package nl.knaw.dans.easy.solr4files
 
+import org.apache.http.HttpStatus._
 import org.scalamock.scalatest.MockFactory
 import org.scalatra.test.scalatest.ScalatraSuite
+
+import scala.util.{ Failure, Success }
+import scalaj.http.HttpResponse
 
 class UpdateServletSpec extends TestSupportFixture
   with ServletFixture
@@ -14,8 +18,59 @@ class UpdateServletSpec extends TestSupportFixture
 
   "get /" should "return the message that the service is running" in {
     get("/") {
-      status shouldBe 200
+      status shouldBe SC_OK
       body shouldBe "EASY File Index is running."
     }
+  }
+
+  "post /update/:store/:uuid" should "return the number of updated files" in {
+    (app.update(_: String, _: String)) expects("pdbs", "9da0541a-d2c8-432e-8129-979a9830b427") once() returning
+      Success("12 files submitted")
+    post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
+      status shouldBe SC_OK
+      body shouldBe "12 files submitted"
+    }
+  }
+
+  it should "return NOT FOUND if uuid is missing" in {
+    post("/update/pdbs/") {
+      status shouldBe SC_NOT_FOUND
+      body should startWith("""Requesting "POST /update/pdbs/" on servlet "" but only have:""")
+    }
+  }
+
+  it should "return NOT FOUND if something is not found for the first file, bag or store" in {
+    (app.update(_: String, _: String)) expects("pdbs", "9da0541a-d2c8-432e-8129-979a9830b427") once() returning
+      Failure(createHttpException(SC_NOT_FOUND))
+    post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
+      status shouldBe SC_NOT_FOUND
+      body shouldBe "getContent(url)"
+    }
+  }
+
+  it should "return NOT FOUND if something is not found for the n-th file, bag or store" in {
+    // TODO check if exceptions from RichUrl.getContent indeed bubble up
+    (app.update(_: String, _: String)) expects("pdbs", "9da0541a-d2c8-432e-8129-979a9830b427") once() returning
+      Failure(MixedResultsException(Seq.empty, createHttpException(SC_NOT_FOUND)))
+    post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
+      status shouldBe SC_NOT_FOUND
+      body shouldBe "Log files should show which actions succeeded. Finally failed with: getContent(url)"
+    }
+  }
+
+  it should "return INTERNAL SERVER ERROR in case of unexpected errors" in {
+    (app.update(_: String, _: String)) expects("pdbs", "9da0541a-d2c8-432e-8129-979a9830b427") once() returning
+      Failure(new Exception())
+    post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
+      status shouldBe SC_INTERNAL_SERVER_ERROR
+      body shouldBe ""
+    }
+  }
+
+  private def createHttpException(code: Int) = {
+    val headers = Map[String, String]("Status" -> "")
+    val r = new HttpResponse[String]("", code, headers)
+    // URL could be a vocabulary for the DDM class or addressing the bag store service
+    HttpStatusException("getContent(url)", r)
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
@@ -17,10 +17,6 @@ package nl.knaw.dans.easy.solr4files
 
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.http.HttpStatus._
-import org.apache.solr.client.solrj.response.UpdateResponse
-import org.apache.solr.client.solrj.{ SolrClient, SolrRequest, SolrResponse }
-import org.apache.solr.common.SolrInputDocument
-import org.apache.solr.common.util.NamedList
 import org.scalamock.scalatest.MockFactory
 import org.scalatra.test.scalatest.ScalatraSuite
 
@@ -32,173 +28,146 @@ class UpdateServletSpec extends TestSupportFixture
   with ScalatraSuite
   with MockFactory {
 
-  private class StubbedWiring extends ApplicationWiring(new Configuration("", new PropertiesConfiguration() {
-    addProperty("solr.url", "http://deasy.dans.knaw.nl:8983/solr/easyfiles")
-    addProperty("vault.url", s"http://deasy.dans.knaw.nl:20110/")
-  })) {
-    override lazy val solrClient: SolrClient = new SolrClient() {
-      // can't use mock because SolrClient has a final method, now we can't count the actual calls
-
-      override def deleteByQuery(q: String): UpdateResponse =
-        throw createHttpException(SC_BAD_REQUEST)
-
-      override def commit(): UpdateResponse =
-        throw new Exception("not expected call")
-
-      override def add(doc: SolrInputDocument): UpdateResponse =
-        throw new Exception("not expected call")
-
-      override def close(): Unit = ()
-
-      override def request(solrRequest: SolrRequest[_ <: SolrResponse], s: String): NamedList[AnyRef] =
-        throw new Exception("not expected call")
+  private class App extends {
+    // mock needs a constructor without arguments
+    private val properties: PropertiesConfiguration = new PropertiesConfiguration() {
+      addProperty("solr.url", "http://deasy.dans.knaw.nl:8983/solr/easyfiles")
+      addProperty("vault.url", "http://deasy.dans.knaw.nl:20110/")
     }
-  }
-
-  private class App extends EasyUpdateSolr4filesIndexApp(null)
-  private val mockedApp = mock[App]
-  private val stubbedDeleteApp = new EasyUpdateSolr4filesIndexApp(new StubbedWiring)
-  addServlet(new EasyUpdateSolr4filesIndexServlet(mockedApp), "/*")
-  //addServlet(new EasyUpdateSolr4filesIndexServlet(stubbedDeleteApp), "/stubbed-delete/*")
+  } with EasyUpdateSolr4filesIndexApp(new ApplicationWiring(new Configuration("", properties)))
+  private val app = mock[App]
+  addServlet(new EasyUpdateSolr4filesIndexServlet(app), "/*")
 
   "get /" should "return the message that the service is running" in {
     get("/") {
-      status shouldBe SC_OK
       body shouldBe "EASY File Index is running."
+      status shouldBe SC_OK
     }
   }
 
   "post /init[/:store]" should "return a feedback message for all stores" in {
-    mockedApp.initAllStores _ expects() once() returning
+    app.initAllStores _ expects() once() returning
       Success("xxx")
     post("/init") {
-      status shouldBe SC_OK
       body shouldBe "xxx"
+      status shouldBe SC_OK
     }
   }
 
   it should "return a feedback message for a single store" in {
-    (mockedApp.initSingleStore(_: String)) expects "pdbs" once() returning
+    (app.initSingleStore(_: String)) expects "pdbs" once() returning
       Success("xxx")
     post("/init/pdbs") {
-      status shouldBe SC_OK
       body shouldBe "xxx"
+      status shouldBe SC_OK
     }
   }
 
   it should "return NOT FOUND for an empty path" in {
     post("/init/") {
-      status shouldBe SC_NOT_FOUND
       body should startWith("""Requesting "POST /init/" on servlet "" but only have:""")
+      status shouldBe SC_NOT_FOUND
     }
   }
 
   "post /update/:store/:uuid" should "return a feedback message" in {
-    (mockedApp.update(_: String, _: String)) expects("pdbs", "9da0541a-d2c8-432e-8129-979a9830b427") once() returning
+    (app.update(_: String, _: String)) expects("pdbs", "9da0541a-d2c8-432e-8129-979a9830b427") once() returning
       Success("12 files submitted")
     post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
-      status shouldBe SC_OK
       body shouldBe "12 files submitted"
+      status shouldBe SC_OK
     }
   }
 
   it should "return NOT FOUND if uuid is missing" in {
     post("/update/pdbs/") {
-      status shouldBe SC_NOT_FOUND
       body should startWith("""Requesting "POST /update/pdbs/" on servlet "" but only have:""")
+      status shouldBe SC_NOT_FOUND
     }
   }
 
   it should "return NOT FOUND if something is not found for the first file, bag or store" in {
-    (mockedApp.update(_: String, _: String)) expects("pdbs", "9da0541a-d2c8-432e-8129-979a9830b427") once() returning
+    (app.update(_: String, _: String)) expects("pdbs", "9da0541a-d2c8-432e-8129-979a9830b427") once() returning
       Failure(createHttpException(SC_NOT_FOUND))
     post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
-      status shouldBe SC_NOT_FOUND
       body shouldBe "getContent(url)"
+      status shouldBe SC_NOT_FOUND
     }
   }
 
   it should "return NOT FOUND with too many path elements" in {
     post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427/") {
-      status shouldBe SC_NOT_FOUND
       body should startWith("""Requesting "POST /update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427/" on servlet "" but only have:""")
+      status shouldBe SC_NOT_FOUND
     }
   }
 
   it should "return NOT FOUND if something is not found for the n-th file, bag or store" in {
     // TODO check if exceptions from getContent indeed bubble up: refactor RichUrl into heavy cake trait
-    (mockedApp.update(_: String, _: String)) expects("pdbs", "9da0541a-d2c8-432e-8129-979a9830b427") once() returning
+    (app.update(_: String, _: String)) expects("pdbs", "9da0541a-d2c8-432e-8129-979a9830b427") once() returning
       Failure(MixedResultsException(Seq.empty, createHttpException(SC_NOT_FOUND)))
     post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
-      status shouldBe SC_NOT_FOUND
       body shouldBe "Log files should show which actions succeeded. Finally failed with: getContent(url)"
+      status shouldBe SC_NOT_FOUND
     }
   }
 
   it should "return INTERNAL SERVER ERROR in case of unexpected errors" in {
-    (mockedApp.update(_: String, _: String)) expects("pdbs", "9da0541a-d2c8-432e-8129-979a9830b427") once() returning
+    (app.update(_: String, _: String)) expects("pdbs", "9da0541a-d2c8-432e-8129-979a9830b427") once() returning
       Failure(new Exception())
     post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
-      status shouldBe SC_INTERNAL_SERVER_ERROR
       body shouldBe ""
+      status shouldBe SC_INTERNAL_SERVER_ERROR
     }
   }
 
   "delete /?q=XXX" should "return a feedback message" in {
-    (mockedApp.delete(_: String)) expects "*:*" once() returning
+    (app.delete(_: String)) expects "*:*" once() returning
       Success("xxx")
     delete("/?q=*:*") {
-      status shouldBe SC_OK
       body shouldBe "xxx"
+      status shouldBe SC_OK
     }
   }
 
   it should "return BAD REQUEST with an invalid query" in {
-    // TODO check the error bubbles up from solrClient.deleteByQuery
-    (mockedApp.delete(_: String)) expects ":" once() returning
+    (app.delete(_: String)) expects ":" once() returning
       Failure(SolrBadRequestException("Cannot parse ':'", new Exception))
     delete("/?q=:") {
-      status shouldBe SC_BAD_REQUEST
       body should startWith("Cannot parse ':'")
+      status shouldBe SC_BAD_REQUEST
     }
   }
 
   it should "complain about the required query" in {
     delete("/") {
-      status shouldBe SC_BAD_REQUEST
       body shouldBe "delete requires param 'q': a solr query"
+      status shouldBe SC_BAD_REQUEST
     }
   }
 
   "delete /:store[/:uuid]" should "return a feedback message with just a store" in {
-    (mockedApp.delete(_: String)) expects "easy_dataset_store_id:pdbs" once() returning
+    (app.delete(_: String)) expects "easy_dataset_store_id:pdbs" once() returning
       Success("xxx")
     delete("/pdbs") {
-      status shouldBe SC_OK
       body shouldBe "xxx"
+      status shouldBe SC_OK
     }
   }
 
-//  it should "return the exception bubbling up from solrClient.deleteByQuery" in {
-//    delete("/stubbed-delete/pdbs") {
-//      status shouldBe SC_OK
-//      body shouldBe "xxx"
-//    }
-//  }
-
   it should "return a feedback message with store and UUID" in {
-    (mockedApp.delete(_: String)) expects "easy_dataset_id:9da0541a-d2c8-432e-8129-979a9830b427" once() returning
+    (app.delete(_: String)) expects "easy_dataset_id:9da0541a-d2c8-432e-8129-979a9830b427" once() returning
       Success("xxx")
     delete("/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
-      status shouldBe SC_OK
       body shouldBe "xxx"
+      status shouldBe SC_OK
     }
   }
 
   it should "return NOT FOUND with too many path elements" in {
     delete("/pdbs/9da0541a-d2c8-432e-8129-979a9830b427/") {
-      status shouldBe SC_NOT_FOUND
       body should startWith("""Requesting "DELETE /pdbs/9da0541a-d2c8-432e-8129-979a9830b427/" on servlet "" but only have:""")
+      status shouldBe SC_NOT_FOUND
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
@@ -40,6 +40,8 @@ class UpdateServletSpec extends TestSupportFixture
   private val app = mock[App]
   addServlet(new EasyUpdateSolr4filesIndexServlet(app), "/*")
 
+  private val uuid = UUID.randomUUID()
+
   "get /" should "return the message that the service is running" in {
     get("/") {
       body shouldBe "EASY File Index is running."
@@ -73,9 +75,9 @@ class UpdateServletSpec extends TestSupportFixture
   }
 
   "post /update/:store/:uuid" should "return a feedback message" in {
-    (app.update(_: String, _: UUID)) expects("pdbs", UUID.fromString("9da0541a-d2c8-432e-8129-979a9830b427")) once() returning
+    (app.update(_: String, _: UUID)) expects("pdbs", uuid) once() returning
       Success("12 files submitted")
-    post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
+    post(s"/update/pdbs/$uuid") {
       body shouldBe "12 files submitted"
       status shouldBe SC_OK
     }
@@ -96,9 +98,9 @@ class UpdateServletSpec extends TestSupportFixture
   }
 
   it should "return NOT FOUND if something is not found for the first file, bag or store" in {
-    (app.update(_: String, _: UUID)) expects("pdbs", UUID.fromString("9da0541a-d2c8-432e-8129-979a9830b427")) once() returning
+    (app.update(_: String, _: UUID)) expects("pdbs", uuid) once() returning
       Failure(createHttpException(SC_NOT_FOUND))
-    post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
+    post(s"/update/pdbs/$uuid") {
       body shouldBe "getContent(url)"
       status shouldBe SC_NOT_FOUND
     }
@@ -106,18 +108,18 @@ class UpdateServletSpec extends TestSupportFixture
 
   it should "return NOT FOUND if something is not found for the n-th file, bag or store" in {
     // TODO check if exceptions from getContent indeed bubble up: refactor RichUrl into heavy cake trait
-    (app.update(_: String, _: UUID)) expects("pdbs", UUID.fromString("9da0541a-d2c8-432e-8129-979a9830b427")) once() returning
+    (app.update(_: String, _: UUID)) expects("pdbs", uuid) once() returning
       Failure(MixedResultsException(Seq.empty, createHttpException(SC_NOT_FOUND)))
-    post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
+    post(s"/update/pdbs/$uuid") {
       body shouldBe "Log files should show which actions succeeded. Finally failed with: getContent(url)"
       status shouldBe SC_NOT_FOUND
     }
   }
 
   it should "return INTERNAL SERVER ERROR in case of unexpected errors" in {
-    (app.update(_: String, _: UUID)) expects("pdbs", UUID.fromString("9da0541a-d2c8-432e-8129-979a9830b427")) once() returning
+    (app.update(_: String, _: UUID)) expects("pdbs", uuid) once() returning
       Failure(new Exception())
-    post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
+    post(s"/update/pdbs/$uuid") {
       body shouldBe ""
       status shouldBe SC_INTERNAL_SERVER_ERROR
     }
@@ -158,9 +160,9 @@ class UpdateServletSpec extends TestSupportFixture
   }
 
   it should "return a feedback message with store and UUID" in {
-    (app.delete(_: String)) expects "easy_dataset_id:9da0541a-d2c8-432e-8129-979a9830b427" once() returning
+    (app.delete(_: String)) expects s"easy_dataset_id:$uuid" once() returning
       Success("xxx")
-    delete("/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
+    delete("/pdbs/" + uuid) {
       body shouldBe "xxx"
       status shouldBe SC_OK
     }

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
@@ -1,0 +1,21 @@
+package nl.knaw.dans.easy.solr4files
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatra.test.scalatest.ScalatraSuite
+
+class UpdateServletSpec extends TestSupportFixture
+  with ServletFixture
+  with ScalatraSuite
+  with MockFactory {
+
+  private class App extends EasyUpdateSolr4filesIndexApp(null)
+  private val app = mock[App]
+  addServlet(new EasyUpdateSolr4filesIndexServlet(app), "/*")
+
+  "get /" should "return the message that the service is running" in {
+    get("/") {
+      status shouldBe 200
+      body shouldBe "EASY File Index is running."
+    }
+  }
+}

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy.solr4files
 
+import java.util.UUID
+
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.http.HttpStatus._
 import org.scalamock.scalatest.MockFactory
@@ -71,7 +73,7 @@ class UpdateServletSpec extends TestSupportFixture
   }
 
   "post /update/:store/:uuid" should "return a feedback message" in {
-    (app.update(_: String, _: String)) expects("pdbs", "9da0541a-d2c8-432e-8129-979a9830b427") once() returning
+    (app.update(_: String, _: UUID)) expects("pdbs", UUID.fromString("9da0541a-d2c8-432e-8129-979a9830b427")) once() returning
       Success("12 files submitted")
     post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
       body shouldBe "12 files submitted"
@@ -86,8 +88,15 @@ class UpdateServletSpec extends TestSupportFixture
     }
   }
 
+  it should "return BAD REQUEST with an invalid uuid" in {
+    post("/update/pdbs/rabarbera") {
+      body shouldBe "Invalid UUID string: rabarbera"
+      status shouldBe SC_BAD_REQUEST
+    }
+  }
+
   it should "return NOT FOUND if something is not found for the first file, bag or store" in {
-    (app.update(_: String, _: String)) expects("pdbs", "9da0541a-d2c8-432e-8129-979a9830b427") once() returning
+    (app.update(_: String, _: UUID)) expects("pdbs", UUID.fromString("9da0541a-d2c8-432e-8129-979a9830b427")) once() returning
       Failure(createHttpException(SC_NOT_FOUND))
     post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
       body shouldBe "getContent(url)"
@@ -104,7 +113,7 @@ class UpdateServletSpec extends TestSupportFixture
 
   it should "return NOT FOUND if something is not found for the n-th file, bag or store" in {
     // TODO check if exceptions from getContent indeed bubble up: refactor RichUrl into heavy cake trait
-    (app.update(_: String, _: String)) expects("pdbs", "9da0541a-d2c8-432e-8129-979a9830b427") once() returning
+    (app.update(_: String, _: UUID)) expects("pdbs", UUID.fromString("9da0541a-d2c8-432e-8129-979a9830b427")) once() returning
       Failure(MixedResultsException(Seq.empty, createHttpException(SC_NOT_FOUND)))
     post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
       body shouldBe "Log files should show which actions succeeded. Finally failed with: getContent(url)"
@@ -113,7 +122,7 @@ class UpdateServletSpec extends TestSupportFixture
   }
 
   it should "return INTERNAL SERVER ERROR in case of unexpected errors" in {
-    (app.update(_: String, _: String)) expects("pdbs", "9da0541a-d2c8-432e-8129-979a9830b427") once() returning
+    (app.update(_: String, _: UUID)) expects("pdbs", UUID.fromString("9da0541a-d2c8-432e-8129-979a9830b427")) once() returning
       Failure(new Exception())
     post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
       body shouldBe ""
@@ -161,6 +170,13 @@ class UpdateServletSpec extends TestSupportFixture
     delete("/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
       body shouldBe "xxx"
       status shouldBe SC_OK
+    }
+  }
+
+  it should "return BAD REQUEST with an invalid UUID" in {
+    delete("/pdbs/rabarbera") {
+      body shouldBe "Invalid UUID string: rabarbera"
+      status shouldBe SC_BAD_REQUEST
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
@@ -104,13 +104,6 @@ class UpdateServletSpec extends TestSupportFixture
     }
   }
 
-  it should "return NOT FOUND with too many path elements" in {
-    post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427/") {
-      body should startWith("""Requesting "POST /update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427/" on servlet "" but only have:""")
-      status shouldBe SC_NOT_FOUND
-    }
-  }
-
   it should "return NOT FOUND if something is not found for the n-th file, bag or store" in {
     // TODO check if exceptions from getContent indeed bubble up: refactor RichUrl into heavy cake trait
     (app.update(_: String, _: UUID)) expects("pdbs", UUID.fromString("9da0541a-d2c8-432e-8129-979a9830b427")) once() returning
@@ -177,13 +170,6 @@ class UpdateServletSpec extends TestSupportFixture
     delete("/pdbs/rabarbera") {
       body shouldBe "Invalid UUID string: rabarbera"
       status shouldBe SC_BAD_REQUEST
-    }
-  }
-
-  it should "return NOT FOUND with too many path elements" in {
-    delete("/pdbs/9da0541a-d2c8-432e-8129-979a9830b427/") {
-      body should startWith("""Requesting "DELETE /pdbs/9da0541a-d2c8-432e-8129-979a9830b427/" on servlet "" but only have:""")
-      status shouldBe SC_NOT_FOUND
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
@@ -38,7 +38,32 @@ class UpdateServletSpec extends TestSupportFixture
     }
   }
 
-  "post /update/:store/:uuid" should "return the number of updated files" in {
+  "post /init[/:store]" should "return a feedback message for all stores" in {
+    app.initAllStores _ expects() once() returning
+      Success("xxx")
+    post("/init") {
+      status shouldBe SC_OK
+      body shouldBe "xxx"
+    }
+  }
+
+  it should "return a feedback message for a single store" in {
+    (app.initSingleStore(_: String)) expects "pdbs" once() returning
+      Success("xxx")
+    post("/init/pdbs") {
+      status shouldBe SC_OK
+      body shouldBe "xxx"
+    }
+  }
+
+  it should "return NOT FOUND for an empty path" in {
+    post("/init/") {
+      status shouldBe SC_NOT_FOUND
+      body should startWith("""Requesting "POST /init/" on servlet "" but only have:""")
+    }
+  }
+
+  "post /update/:store/:uuid" should "return a feedback message" in {
     (app.update(_: String, _: String)) expects("pdbs", "9da0541a-d2c8-432e-8129-979a9830b427") once() returning
       Success("12 files submitted")
     post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427") {
@@ -64,9 +89,9 @@ class UpdateServletSpec extends TestSupportFixture
   }
 
   it should "return NOT FOUND with too many path elements" in {
-    post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427/rabarbara") {
+    post("/update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427/") {
       status shouldBe SC_NOT_FOUND
-      body should startWith("""Requesting "POST /update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427/rabarbara" on servlet "" but only have:""")
+      body should startWith("""Requesting "POST /update/pdbs/9da0541a-d2c8-432e-8129-979a9830b427/" on servlet "" but only have:""")
     }
   }
 
@@ -101,7 +126,7 @@ class UpdateServletSpec extends TestSupportFixture
   it should "return BAD REQUEST with an invalid query" in {
     // TODO check the error bubbles up from solrClient.deleteByQuery
     (app.delete(_: String)) expects ":" once() returning
-      Failure(SolrBadRequestException("Cannot parse ':'",new Exception))
+      Failure(SolrBadRequestException("Cannot parse ':'", new Exception))
     delete("/?q=:") {
       status shouldBe SC_BAD_REQUEST
       body should startWith("Cannot parse ':'")
@@ -134,9 +159,9 @@ class UpdateServletSpec extends TestSupportFixture
   }
 
   it should "return NOT FOUND with too many path elements" in {
-    delete("/pdbs/9da0541a-d2c8-432e-8129-979a9830b427/rabarbara") {
+    delete("/pdbs/9da0541a-d2c8-432e-8129-979a9830b427/") {
       status shouldBe SC_NOT_FOUND
-      body should startWith("""Requesting "DELETE /pdbs/9da0541a-d2c8-432e-8129-979a9830b427/rabarbara" on servlet "" but only have:""")
+      body should startWith("""Requesting "DELETE /pdbs/9da0541a-d2c8-432e-8129-979a9830b427/" on servlet "" but only have:""")
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/components/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/components/DDMSpec.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy.solr4files.components
 
+import java.util.UUID
+
 import nl.knaw.dans.easy.solr4files.{ TestSupportFixture, _ }
 
 class DDMSpec extends TestSupportFixture {
@@ -23,7 +25,7 @@ class DDMSpec extends TestSupportFixture {
 
   "solrLiteral" should "return proper values" in {
     assume(canConnectToEasySchemas)
-    val uuid = "9da0541a-d2c8-432e-8129-979a9830b427"
+    val uuid = UUID.fromString("9da0541a-d2c8-432e-8129-979a9830b427")
     val xml = vault.fileURL("pdbs", uuid, "metadata/dataset.xml").flatMap(_.loadXml).getOrElse(<ddm/>)
 
     val ddm = new DDM(xml)

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/components/FileItemSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/components/FileItemSpec.scala
@@ -15,13 +15,15 @@
  */
 package nl.knaw.dans.easy.solr4files.components
 
+import java.util.UUID
+
 import nl.knaw.dans.easy.solr4files.TestSupportFixture
 
 class FileItemSpec extends TestSupportFixture {
 
   private val bag = Bag(
     "pdbs",
-    "9da0541a-d2c8-432e-8129-979a9830b427",
+    UUID.fromString("9da0541a-d2c8-432e-8129-979a9830b427"),
     mockVault("vault")
   )
 

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/components/VaultSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/components/VaultSpec.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy.solr4files.components
 
+import java.util.UUID
+
 import nl.knaw.dans.easy.solr4files.TestSupportFixture
 
 import scala.util.Success
@@ -30,11 +32,11 @@ class VaultSpec extends TestSupportFixture {
   "getBagIds" should "return UUID's" in {
     inside(mockVault("vaultBagIds").getBagIds("pdbs")) {
       case Success(names) => names should contain only(
-        "9da0541a-d2c8-432e-8129-979a9830b427",
-        "24d305fc-060c-4b3b-a5f5-9f212d463cbc",
-        "3528bd4c-a87a-4bfa-9741-a25db7ef758a",
-        "f70c19a5-0725-4950-aa42-6489a9d73806",
-        "6ccadbad-650c-47ec-936d-2ef42e5f3cda")
+        UUID.fromString("9da0541a-d2c8-432e-8129-979a9830b427"),
+        UUID.fromString("24d305fc-060c-4b3b-a5f5-9f212d463cbc"),
+        UUID.fromString("3528bd4c-a87a-4bfa-9741-a25db7ef758a"),
+        UUID.fromString("f70c19a5-0725-4950-aa42-6489a9d73806"),
+        UUID.fromString("6ccadbad-650c-47ec-936d-2ef42e5f3cda"))
     }
   }
 }


### PR DESCRIPTION
Fixes another chunk of EASY-1320

#### When applied it will
* have commands made available as http request
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

The changes in the readme which should reflect the servlet class.

#### How should this be manually tested?

* `mvn clean install && vagrant destroy -f && vagrant up`
* Check the result in your browser with `http://test.dans.knaw.nl:8983/solr/#/fileitems/query`, you should find nothing.
* `curl -X POST 'http://test.dans.knaw.nl/fileindex/init'`
  it should report one bag for the pdbs store.
* Repeat the check with the browser. Now you should find 9 file items.
* `curl -X DELETE 'http://test.dans.knaw.nl/fileindex/?q=attr_easy_dataset_store_id:pdbs'`
* Repeat the check with the browser. Now you should find nothing again.

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
