### PR TITLE
EASY-1325 search 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ Method   | Path                             | Action
 `GET`    | `/filesearch`                    | Return indexed metadata. Not known parameters are ignored.
 
 
-Parameters for `filesearch` | description
+Parameters for `filesearch` | Description
 ----------------------------|----------------
-`text`                      | The query for the textual content. Mandatory, the `q` parameter of a [dismax] query.
+`text`                      | The query for the textual content, mandatory. Becomes the `q` parameter of a [dismax] query.
 `skip`                      | For result paging, default 0.
 `limit`                     | For result paging, default 10.
-`dataset_id`, `dataset_doi` | Restrict to one or some datasets, optional. Repeating just one type of the identifiers return items for each value. Mixing identifier types only returns items matching at least one of the values for each type.
-`dataset_depositor_id`      | Restrict to the specific dataset field, optional. Repeating a field return items with at least one of the values. Specifying multiple fields only returns items matching at least one of the values for each field.
+`dataset_id`, `dataset_doi` | Restrict to one or some datasets, optional. Repeating just one type of the identifiers returns items for each value. Mixing identifier types only returns items matching at least one of the values for each type.
+`dataset_depositor_id`      | Restrict to the specific dataset field, optional. Repeating a field returns items with at least one of the values. Specifying multiple fields only returns items matching at least one of the values for each field.
 `file_mime_type`            | ,,
 `file_size`                 | ,,
 `file_checksum`             | ,,

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ SYNOPSIS
     easy-update-solr4files-index init <bag-store>
     easy-update-solr4files-index run-service
     easy-update-solr4files-index delete <solr-query>
+    easy-update-solr4files-index run-service
     
     Some examples of [standard] solr queries for the delete command:
     
@@ -36,22 +37,33 @@ When started with the sub-command `run-service` a REST API becomes available sum
 "Method" refers to the HTTP method used in the request. "Path" is the path pattern used. 
 Placeholders for variables start with a colon, optional parts are enclosed in square brackets.
 
-Method   | Path                             | Args  |Action
----------|----------------------------------|-------|------------------------------------
-`GET`    | `/fileindex`                     |       | Return a simple message to indicate that the service is up: "EASY File index is running."
-`POST`   | `/fileindex/init[/:store]`       |       | Index all bag stores or just one. Eventual obsolete items are cleared.
-`POST`   | `/fileindex/update/:store/:uuid` |       | Index all files of one bag. Eventual obsolete file items are cleared.
-`DELETE` | `/fileindex/:store[/:uuid]`      |       | Remove all items or the items of a store or bag.
-`DELETE` | `/fileindex/`                    | q     | Remove the items matching the mandatory [standard] solr query.
-`GET`    | `/filesearch`                    |       | Return indexed metadata. Not known arguments are ignored. Defaults are used for optional arguments with invalid values.
-         |                                  | text  | Mandatory, a [dismax] query.
-         |                                  | skip  | Optional, default 0 (zero), the number of rows of the query result to skip in the response.
-         |                                  | limit | Optional, default 10, the maximum number of rows to return in the response.
+Method   | Path                             | Action
+---------|----------------------------------|------------------------------------
+`GET`    | `/fileindex`                     | Return a simple message to indicate that the service is up: "EASY File index is running."
+`POST`   | `/fileindex/init[/:store]`       | Index all bag stores or just one. Eventual obsolete items are cleared.
+`POST`   | `/fileindex/update/:store/:uuid` | Index all files of one bag. Eventual obsolete file items are cleared.
+`DELETE` | `/fileindex/:store[/:uuid]`      | Remove all items from the index or the items of a store or bag.
+`DELETE` | `/fileindex/`                    | Requires parameter q, a mandatory [standard] solr query that specifies the items to remove from the index.
+`GET`    | `/filesearch`                    | Return indexed metadata. Not known parameters are ignored.
 
-The following example would delete a bag from the index
 
-    curl -X DELETE 'http://easy.dans.knaw.nl/fileindex/?q=easy_dataset_id:ef425828-e4ae-4d58-bf6a-c89cd46df61c'
-    
+Parameters for `filesearch` | description
+----------------------------|----------------
+`text`                      | The query for the textual content. Mandatory, the `q` parameter of a [dismax] query.
+`skip`                      | For result paging, default 0.
+`limit`                     | For result paging, default 10.
+`dataset_id`, `dataset_doi` | Restrict to one or some datasets, optional. Repeating just one type of the identifiers return items for each value. Mixing identifier types only returns items matching at least one of the values for each type.
+`dataset_depositor_id`      | Restrict to the specific dataset field, optional. Repeating a field return items with at least one of the values. Specifying multiple fields only returns items matching at least one of the values for each field.
+`file_mime_type`            | ,,
+`file_size`                 | ,,
+`file_checksum`             | ,,
+`dataset_title`             | ,,
+`dataset_creator`           | ,,
+`dataset_audience`          | ,,
+`dataset_relation`          | ,,
+`dataset_subject`           | ,,
+`dataset_coverage`          | ,,
+
 [dismax]: https://lucene.apache.org/solr/guide/6_6/the-dismax-query-parser.html#the-dismax-query-parser
 [standard]: https://lucene.apache.org/solr/guide/6_6/the-standard-query-parser.html
 
@@ -105,7 +117,20 @@ ARGUMENTS
 EXAMPLES
 --------
 
-    easy-update-solr4files-index update 9da0541a-d2c8-432e-8129-979a9830b427
+Using the command line to update a single bag in the store `pdbs` respective (re)index all bags in all stores.
+
+    easy-update-solr4files-index -s pdbs update 9da0541a-d2c8-432e-8129-979a9830b427
+    easy-update-solr4files-index init
+
+Using the rest interface to delete a bag from the index respective (re)index all bags in one store.
+
+    curl -X DELETE 'http://test.dans.knaw.nl:20150/fileindex/?q=easy_dataset_id:ef425828-e4ae-4d58-bf6a-c89cd46df61c'
+    curl -X POST 'http://test.dans.knaw.nl:20150/fileindex/init/pdbs'
+
+Retrieve the second page of PDF and text files containing one of the words `foo` or `bar`.
+See the [security advice](#security-advice) for the URL part preceding the `?`.
+
+    curl 'http://test.dans.knaw.nl:20150/filesearch?text=foo+bar&file_mime_type=application/pdf&file_mime_type=text&skip=10&limit=10'
 
 
 INSTALLATION AND CONFIGURATION

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ SYNOPSIS
     easy-update-solr4files-index delete <solr-query>
     easy-update-solr4files-index run-service
     
-    Some examples of [standard] solr queries for the delete command:
+    Some examples of standard solr queries for the delete command:
     
       everything:            '*:*'
       all bags of one store: 'easy_dataset_store_id:pdbs'
@@ -44,16 +44,16 @@ Method   | Path                             | Action
 `POST`   | `/fileindex/update/:store/:uuid` | Index all files of one bag. Eventual obsolete file items are cleared.
 `DELETE` | `/fileindex/:store[/:uuid]`      | Remove all items from the index or the items of a store or bag.
 `DELETE` | `/fileindex/`                    | Requires parameter q, a mandatory [standard] solr query that specifies the items to remove from the index.
-`GET`    | `/filesearch`                    | Return indexed metadata. Not known parameters are ignored.
+`GET`    | `/filesearch`                    | Return indexed metadata. Query parameters are optional, not known parameters are ignored.
 
 
 Parameters for `filesearch` | Description
 ----------------------------|----------------
-`text`                      | The query for the textual content, mandatory. Becomes the `q` parameter of a [dismax] query.
+`text`                      | The query for the textual content. Becomes the `q` parameter of a [dismax] query. If not specified all accessible items are returned unless a restriction is specified.
 `skip`                      | For result paging, default 0.
 `limit`                     | For result paging, default 10.
-`dataset_id`, `dataset_doi` | Restrict to one or some datasets, optional. Repeating just one type of the identifiers returns items for each value. Mixing identifier types only returns items matching at least one of the values for each type.
-`dataset_depositor_id`      | Restrict to the specific dataset field, optional. Repeating a field returns items with at least one of the values. Specifying multiple fields only returns items matching at least one of the values for each field.
+`dataset_id`, `dataset_doi` | Restrict to one or some datasets. Repeating just one type of the identifiers returns items for each value. Mixing identifier types only returns items matching at least one of the values for each type.
+`dataset_depositor_id`      | Restrict to the specific dataset field. Repeating a field returns items with at least one of the values. Specifying multiple fields only returns items matching at least one of the values for each field.
 `file_mime_type`            | ,,
 `file_size`                 | ,,
 `file_checksum`             | ,,

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,4 @@
-system "ansible-galaxy install -r #{File.dirname(File.expand_path(__FILE__))}/src/main/ansible/requirements.yml"
+system "ansible-galaxy install --force --role-file=#{File.dirname(File.expand_path(__FILE__))}/src/main/ansible/requirements.yml"
 Vagrant.configure(2) do |config|
    config.vm.define "test" do |test|
       test.vm.box = "geerlingguy/centos6"

--- a/src/main/ansible/requirements.yml
+++ b/src/main/ansible/requirements.yml
@@ -21,6 +21,6 @@
 - src: https://github.com/DANS-KNAW/dans.solr
   version: 3.6.3-dans
 - src: https://github.com/DANS-KNAW/dans.easy-ldap-dir
-  version: 2.0.2
+  version: v2.0.2
 - src: https://github.com/DANS-KNAW/dans.easy-test-users
-  version: 1.2.0
+  version: v1.2.0

--- a/src/main/assembly/dist/install/fileitems/schema.xml
+++ b/src/main/assembly/dist/install/fileitems/schema.xml
@@ -184,6 +184,9 @@
     <field name="easy_file_path" type="string" indexed="true" stored="true" required="true"/>
     <field name="easy_file_accessible_to" type="string" indexed="true" stored="true" required="true"/>
     <field name="easy_file_mime_type" type="string" indexed="true" stored="true" required="true"/>
+
+    <field name="easy_dataset_date_available" type="date" indexed="true" stored="true" required="true" multiValued="false"/>
+
     <!-- size should be a number, long so we can search for smaller or larger -->
     <field name="easy_file_size" type="string" indexed="true" stored="true"/>
     <field name="easy_file_checksum" type="string" indexed="true" stored="true"/>
@@ -194,7 +197,6 @@
     <!-- note that audience is a 'code', the readable labels are placed in easy_dataset_subject -->
     <field name="easy_dataset_audience" type="string" indexed="true" stored="true" required="true" multiValued="true"/>
     <!-- not required -->
-    <field name="easy_dataset_date_available" type="date" indexed="true" stored="true" multiValued="false"/>
     <field name="easy_file_title" type="text_general" indexed="true" stored="true"/>
     <field name="easy_dataset_relation" type="text_general" indexed="true" stored="true" multiValued="true"/>
     <field name="easy_dataset_identifier" type="text_general" indexed="true" stored="true" multiValued="true"/>

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
@@ -25,7 +25,6 @@ import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
 
-import scala.collection.JavaConverters._
 import scala.util.{ Failure, Try }
 import scala.xml.Elem
 

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/CommandLineOptions.scala
@@ -34,6 +34,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
        |  $printedName init <bag-store>
        |  $printedName run-service
        |  $printedName delete <solr-query>
+       |  $printedName run-service
        |
        |  Some examples of [standard] solr queries for the delete command:
        |

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/CommandLineOptions.scala
@@ -36,7 +36,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
        |  $printedName delete <solr-query>
        |  $printedName run-service
        |
-       |  Some examples of [standard] solr queries for the delete command:
+       |  Some examples of standard solr queries for the delete command:
        |
        |    everything:            '*:*'
        |    all bags of one store: 'easy_dataset_store_id:pdbs'

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/SearchServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/SearchServlet.scala
@@ -58,7 +58,7 @@ class SearchServlet(app: EasyUpdateSolr4filesIndexApp) extends ScalatraServlet w
       case (Some(q), Success(user)) => respond(app.search(createQuery(q, user)))
       case (Some(_), Failure(InvalidUserPasswordException(_, _))) => Unauthorized()
       case (Some(_), Failure(AuthorisationNotAvailableException(_))) => ServiceUnavailable("Authentication service not available, try anonymous search")
-      case (Some(_), Failure(AuthorisationTypeNotSupportedException(_))) => ServiceUnavailable("Only anonymous search or basic authentication supported")
+      case (Some(_), Failure(AuthorisationTypeNotSupportedException(_))) => BadRequest("Only anonymous search or basic authentication supported")
       case (Some(_), Failure(t)) =>
         logger.error(t.getMessage, t)
         InternalServerError()
@@ -129,7 +129,7 @@ class SearchServlet(app: EasyUpdateSolr4filesIndexApp) extends ScalatraServlet w
       "dataset_relation",
       "dataset_subject",
       "dataset_coverage"
-    ).map ( key =>
+    ).map(key =>
       params
         .get(key)
         .map(value => s"easy_$key:$value") // TODO prevent injection, bad-request on invalid values?

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/AuthenticationComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/AuthenticationComponent.scala
@@ -31,7 +31,7 @@ trait AuthenticationComponent extends DebugEnhancedLogging {
       (authRequest.providesAuth, authRequest.isBasicAuth) match {
         case (true, true) => getUser(authRequest.username, authRequest.password).map(Some(_))
         case (true, _) => Failure(AuthorisationTypeNotSupportedException(new Exception("Supporting only basic authentication")))
-        case (_,_) => Success(None)
+        case (_, _) => Success(None)
       }
     }
 

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/LdapAuthenticationComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/LdapAuthenticationComponent.scala
@@ -15,9 +15,7 @@
  */
 package nl.knaw.dans.easy.solr4files.components
 
-import java.security.MessageDigest
 import java.util
-import java.util.Base64
 import javax.naming.directory.{ SearchControls, SearchResult }
 import javax.naming.ldap.{ InitialLdapContext, LdapContext }
 import javax.naming.{ AuthenticationException, Context, NamingEnumeration }
@@ -37,12 +35,14 @@ trait LdapAuthenticationComponent extends AuthenticationComponent {
     def getUser(userName: String, password: String): Try[User] = {
 
       logger.info(s"looking for user [$userName]")
+
       def toUser(searchResult: SearchResult) = {
         def getAttrs(key: String) = {
           Option(searchResult.getAttributes.get(key)).map(
             _.getAll.asScala.toList.map(_.toString)
           ).getOrElse(Seq.empty)
         }
+
         val roles = getAttrs("easyRoles")
         User(userName,
           isArchivist = roles.contains("ARCHIVIST"),

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -98,7 +98,7 @@ trait Solr extends DebugEnhancedLogging {
     (for {
       response <- Try(solrClient.query(query))
       _ <- checkResponseStatus(response)
-    } yield toJson(response.getResults, query)
+    } yield toJson(response.getResults, query) // .getFacet.Xxx, .getGroupXxx .getSortedXxx .getMoreLikeXxx etc.
       ).recoverWith {
       case t: HttpSolrClient.RemoteSolrException if isParseException(t) =>
         Failure(SolrBadRequestException(t.getMessage, t))
@@ -165,7 +165,7 @@ object Solr {
       fieldValueMap
         .keySet()
         .asScala
-        .map(key => JField(key.replace("easy_",""), fieldValueMap.get(key).toString))
+        .map(key => JField(key.replace("easy_", ""), fieldValueMap.get(key).toString))
         .toList
     }
   }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -77,8 +77,7 @@ trait Solr extends DebugEnhancedLogging {
 
 
   private def toJson(solrDocumentList: SolrDocumentList, query: SolrQuery): String = {
-    val numFound = solrDocumentList.getNumFound
-    val fileItems = (0L until numFound).map { i =>
+    val fileItems = (0L until solrDocumentList.size()).map { i =>
       solrDocumentList.get(i.toInt).getFieldValueMap.toJObject
     }
     val result =
@@ -87,7 +86,7 @@ trait Solr extends DebugEnhancedLogging {
           ("skip" -> query.getStart.toInt) ~
           ("limit" -> query.getRows.toInt) ~
           ("time_allowed" -> query.getTimeAllowed.toInt) ~
-          ("found" -> numFound) ~
+          ("found" -> solrDocumentList.getNumFound) ~
           ("returned" -> fileItems.size)
         )) ~
         ("fileitems" -> fileItems)

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -165,7 +165,7 @@ object Solr {
       fieldValueMap
         .keySet()
         .asScala
-        .map(key => JField(key, fieldValueMap.get(key).toString))
+        .map(key => JField(key.replace("easy_",""), fieldValueMap.get(key).toString))
         .toList
     }
   }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -81,7 +81,7 @@ trait Solr extends DebugEnhancedLogging {
       solrDocumentList.get(i.toInt).getFieldValueMap.toJObject
     }
     val result =
-      ("header" -> (
+      ("summary" -> (
         ("text" -> query.getQuery) ~
           ("skip" -> query.getStart.toInt) ~
           ("limit" -> query.getRows.toInt) ~

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Vault.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Vault.scala
@@ -39,7 +39,7 @@ trait Vault extends DebugEnhancedLogging {
   }
 
   def getBagIds(storeName: String): Try[Seq[UUID]] = for {
-  // no state param (in fact no param at all) so we just get the active bags
+    // no state param (in fact no param at all) so we just get the active bags
     storeURI <- Try(vaultBaseUri.resolve(s"stores/$storeName/bags"))
     lines <- storeURI.toURL.readLines
   } yield lines

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/ApplicationWiringSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/ApplicationWiringSpec.scala
@@ -17,7 +17,6 @@ package nl.knaw.dans.easy.solr4files
 
 import java.util.UUID
 
-import nl.knaw.dans.easy.solr4files.components.{ Bag, FileItem }
 import org.apache.commons.io.FileUtils.write
 import org.apache.solr.client.solrj.request.ContentStreamUpdateRequest
 import org.apache.solr.client.solrj.response.UpdateResponse

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/ReadmeSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/ReadmeSpec.scala
@@ -19,6 +19,8 @@ import java.io.{ ByteArrayOutputStream, File }
 
 import org.scalatest._
 
+import scala.io.Source
+
 class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
   System.setProperty("app.home", "src/main/assembly/dist") // Use the default settings in this test
 
@@ -49,5 +51,12 @@ class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
   "description line(s) in help info" should "be part of README.md and pom.xml" in {
     new File("README.md") should containTrimmed(clo.description)
     new File("pom.xml") should containTrimmed(clo.description)
+  }
+
+  "user filters" should "be listed in README.md" in {
+    val readme = Source.fromFile(new File("README.md")).mkString
+    SearchServlet.userFilters.foreach(
+      s => readme should include(s"`$s`")
+    )
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/SearchServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/SearchServletSpec.scala
@@ -82,7 +82,7 @@ class SearchServletSpec extends TestSupportFixture
       header.get("Content-Type") shouldBe Some("application/json;charset=UTF-8")
       body should startWith(
         """{
-          |  "header":{
+          |  "summary":{
           |    "text":"something",
           |    "skip":0,
           |    "limit":10,

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/SearchServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/SearchServletSpec.scala
@@ -41,7 +41,7 @@ class SearchServletSpec extends TestSupportFixture
       override def close(): Unit = ()
 
       override def request(solrRequest: SolrRequest[_ <: SolrResponse], s: String): NamedList[AnyRef] =
-        throw new Exception("mocked request")
+        throw new Exception("not expected call")
     }
 
     private def mockQueryResponse(params: SolrParams) = {
@@ -51,14 +51,16 @@ class SearchServletSpec extends TestSupportFixture
           setStart(0)
           add(new SolrDocument(new java.util.TreeMap[String, AnyRef] {
             put("debug", s"$params")
+            // just for these tests: allows to verify what was sent to solr
+            // so far any other part of the response is static for all tests
           }))
           add(new SolrDocument(new java.util.HashMap[String, AnyRef] {
-            put("name", "file.txt")
+            put("easy_file_name", "file.txt")
           }))
           add(new SolrDocument(new java.util.TreeMap[String, AnyRef] {
             // a sorted order makes testing easier
-            put("name", "some.png")
-            put("size", "123")
+            put("easy_file_name", "some.png")
+            put("easy_file_size", "123")
           }))
         }
       }
@@ -93,12 +95,12 @@ class SearchServletSpec extends TestSupportFixture
           |""".stripMargin)
       body should include(
         """{
-          |    "name":"file.txt"
+          |    "file_name":"file.txt"
           |  }""".stripMargin)
       body should include(
         """{
-          |    "name":"some.png",
-          |    "size":"123"
+          |    "file_name":"some.png",
+          |    "file_size":"123"
           |  }""".stripMargin)
       body should endWith(
         """

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
@@ -74,6 +74,7 @@ class SolrErrorHandlingSpec extends TestSupportFixture
   }
 
   "submit" should "return the exception bubbling up from solrClient.request" in {
+    assume(canConnectToEasySchemas)
     initVault()
     post(s"/fileindex/update/pdbs/${ uuidCentaur }") {
       body shouldBe s"solr update of file ${ uuidCentaur }/data/path/to/a/random/video/hubble.mpg failed with mocked add"

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/TestSupportFixture.scala
@@ -36,8 +36,8 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
     path
   }
 
-  val uuidCentaur = UUID.fromString("9da0541a-d2c8-432e-8129-979a9830b427")
-  val uuidAnonymized = UUID.fromString("1afcc4e9-2130-46cc-8faf-2663e199b218")
+  val uuidCentaur: UUID = UUID.fromString("9da0541a-d2c8-432e-8129-979a9830b427")
+  val uuidAnonymized: UUID = UUID.fromString("1afcc4e9-2130-46cc-8faf-2663e199b218")
 
   val mockedVault: Vault = new Vault {
     // vault/stores is sometimes a folder, sometimes a dir
@@ -64,7 +64,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
   /** assume(canConnectToEasySchemas) allows to build when offline */
   def canConnectToEasySchemas: Boolean = Try {
     // allows to build when offline
-    new URL("http://easy.dans.knaw.nl/schemas").openConnection match {
+    new URL("https://easy.dans.knaw.nl/schemas").openConnection match {
       case connection: HttpURLConnection =>
         connection.setConnectTimeout(1000)
         connection.setReadTimeout(1000)

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/components/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/components/DDMSpec.scala
@@ -15,8 +15,6 @@
  */
 package nl.knaw.dans.easy.solr4files.components
 
-import java.util.UUID
-
 import nl.knaw.dans.easy.solr4files.{ TestSupportFixture, _ }
 
 class DDMSpec extends TestSupportFixture {

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/components/FileItemSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/components/FileItemSpec.scala
@@ -15,8 +15,6 @@
  */
 package nl.knaw.dans.easy.solr4files.components
 
-import java.util.UUID
-
 import nl.knaw.dans.easy.solr4files.TestSupportFixture
 
 class FileItemSpec extends TestSupportFixture {


### PR DESCRIPTION
Fixes EASY-1325

#### When applied it will
* [ ] fix first time deployment
* require date-availble in DDM
* allow user to restrict the search result with filters

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

See #9, the following command should return only pdf and text files
```
curl 'http://test.dans.knaw.nl:20150/filesearch?text=was+van+standaard&file_mime_type=application/pdf&file_mime_type=text/plain' | grep 'path'
```

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
