### PR TITLE
Fix slow update with large files

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
@@ -141,7 +141,7 @@ class ApplicationWiring(configuration: Configuration)
       .map(FileItem(bag, ddm, _))
       .filter(_.shouldIndex)
       .toStream
-      .map(f => createDoc(f, getSize(f.bag.storeName, f.bag.bagId, f.path)))
+      .map(f => createDoc(f))
       .takeUntilFailure
       .doIfFailure { case MixedResultsException(results: Seq[_], _) => results.foreach(fb => logger.info(fb.toString)) }
       .map(results => BagSubmitted(bag.bagId.toString, results))

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Bag.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Bag.scala
@@ -45,6 +45,9 @@ case class Bag(storeName: String,
     vault.fileURL(storeName, bagId, path)
   }
 
+  def fileSize(path: String): Long = {
+    vault.getSize(storeName, bagId, path)
+  }
 
   // splits a string on the first sequence of white space after the sha
   // the rest is a path that might contain white space

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/FileItem.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/FileItem.scala
@@ -47,6 +47,15 @@ case class FileItem(bag: Bag, ddm: DDM, xml: Node) extends DebugEnhancedLogging 
     path.nonEmpty && accessible.contains(accessibleTo)
   }
 
+  lazy val size: Long = bag.fileSize(path)
+
+  val shouldSubmitWithContent: Boolean = {
+    // prevent content submission and extraction for large files, to keep it fast
+    // TODO make this value configurable
+    val maxFileSizeToExtractContentFrom = 64*1024*1024
+    size <= maxFileSizeToExtractContentFrom
+  }
+
   val mimeType: String = (xml \ "format").text
 
   // lazy postpones loading Bag.sha's

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -42,10 +42,10 @@ trait Solr extends DebugEnhancedLogging {
   val solrUrl: URL
   lazy val solrClient: SolrClient = new HttpSolrClient.Builder(solrUrl.toString).build()
 
-  def createDoc(item: FileItem, size: Long): Try[FileFeedback] = {
+  def createDoc(item: FileItem): Try[FileFeedback] = {
     item.bag.fileUrl(item.path).flatMap { fileUrl =>
       val solrDocId = s"${ item.bag.bagId }/${ item.path }"
-      val solrFields = (item.bag.solrLiterals ++ item.ddm.solrLiterals ++ item.solrLiterals :+ "file_size" -> size.toString)
+      val solrFields = (item.bag.solrLiterals ++ item.ddm.solrLiterals ++ item.solrLiterals :+ "file_size" -> item.size.toString)
         .map { case (k, v) => (k, v.replaceAll("\\s+", " ").trim) }
         .filter { case (_, v) => v.nonEmpty }
       if (logger.underlying.isDebugEnabled) logger.debug(solrFields

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -52,12 +52,18 @@ trait Solr extends DebugEnhancedLogging {
         .map { case (key, value) => s"$key = $value" }
         .mkString("\n\t")
       )
-      submitWithContent(fileUrl, solrDocId, solrFields)
-        .map(_ => FileSubmittedWithContent(solrDocId))
-        .recoverWith { case t =>
-          logger.warn(s"Submission with content of [$solrDocId] failed with ${ t.getMessage }")
-          resubmitMetadata(solrDocId, solrFields).map(_ => FileSubmittedWithJustMetadata(solrDocId))
-        }
+      if (!item.shouldSubmitWithContent) {
+        logger.info(s"Submission without content of [$solrDocId]")
+        submitWithOnlyMetadata(solrDocId, solrFields).map(_ => FileSubmittedWithOnlyMetadata(solrDocId))
+      } else {
+        logger.info(s"Submission with content of [$solrDocId]")
+        submitWithContent(fileUrl, solrDocId, solrFields)
+          .map(_ => FileSubmittedWithContent(solrDocId))
+          .recoverWith { case t =>
+            logger.warn(s"Submission with content of [$solrDocId] failed with ${ t.getMessage }")
+            submitWithOnlyMetadata(solrDocId, solrFields).map(_ => FileSubmittedWithOnlyMetadata(solrDocId))
+          }
+      }
     }
   }
 
@@ -128,7 +134,7 @@ trait Solr extends DebugEnhancedLogging {
     })).flatMap(checkSolrStatus)
   }
 
-  private def resubmitMetadata(solrDocId: String, solrFields: SolrLiterals) = {
+  private def submitWithOnlyMetadata(solrDocId: String, solrFields: SolrLiterals) = {
     Try(solrClient.add(new SolrInputDocument() {
       for ((k, v) <- solrFields) {
         addField(s"easy_$k", v)
@@ -138,7 +144,6 @@ trait Solr extends DebugEnhancedLogging {
       .flatMap(checkResponseStatus)
       .recoverWith { case t => Failure(SolrUpdateException(solrDocId, t)) }
   }
-
 
   private def checkResponseStatus[T <: SolrResponseBase](response: T): Try[T] = {
     // this method hides the inconsistent design of the solr library from the rest of the code

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
@@ -100,7 +100,7 @@ package object solr4files extends DebugEnhancedLogging {
   abstract sealed class Feedback(val msg: String)
   abstract sealed class FileFeedback(override val msg: String) extends Feedback(msg)
   case class FileSubmittedWithContent(override val msg: String) extends FileFeedback(msg)
-  case class FileSubmittedWithJustMetadata(override val msg: String) extends FileFeedback(msg) {
+  case class FileSubmittedWithOnlyMetadata(override val msg: String) extends FileFeedback(msg) {
     logger.warn(s"Resubmitted $msg with just metadata")
   }
   case class StoreSubmitted(override val msg: String) extends Feedback(msg)

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/ApplicationWiringSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/ApplicationWiringSpec.scala
@@ -74,7 +74,7 @@ class ApplicationWiringSpec extends TestSupportFixture {
     assume(canConnectToEasySchemas)
     val result = new MockedAndStubbedWiring().update(store, uuidCentaur)
     inside(result) { case Success(feedback) =>
-      feedback.toString shouldBe s"Bag ${ uuidCentaur }: 7 times FileSubmittedWithContent, 2 times FileSubmittedWithJustMetadata"
+      feedback.toString shouldBe s"Bag ${ uuidCentaur }: 7 times FileSubmittedWithContent, 2 times FileSubmittedWithOnlyMetadata"
     }
   }
 


### PR DESCRIPTION
Fixes slow update with large files

- [x] Initial implementation
- [x] Integration testing is successful

#### When applied it will
* Not submit the content, but only the metadata, when the file is larger than 64MB

#### Where should the reviewer @DANS-KNAW/easy start?
Solr.scala the createDoc function, look for the condition shouldSubmitWithContent

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..