### PR TITLE
NO JIRA: Remove dataset_depositor_id from search results

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -169,6 +169,7 @@ object Solr {
       fieldValueMap
         .keySet()
         .asScala
+        .filter(_ != "easy_dataset_depositor_id")
         .map(key => JField(key.replace("easy_", ""), fieldValueMap.get(key).toString))
         .toList
     }


### PR DESCRIPTION
Fixes exposing depositor id in search results

#### When applied it will
* Not give the dataset_depositor_id in the search results 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
Check the search results, is will not contain the dataset_depositor_id

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..