### PR TITLE
NO JIRA: Skip whitespace normalise for file_path

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -46,7 +46,10 @@ trait Solr extends DebugEnhancedLogging {
     item.bag.fileUrl(item.path).flatMap { fileUrl =>
       val solrDocId = s"${ item.bag.bagId }/${ item.path }"
       val solrFields = (item.bag.solrLiterals ++ item.ddm.solrLiterals ++ item.solrLiterals :+ "file_size" -> item.size.toString)
-        .map { case (k, v) => (k, v.replaceAll("\\s+", " ").trim) }
+        .map {
+          case (k, v) if k == "file_path" => (k, v.trim) // do not normalise whitespace in filepath
+          case (k, v) => (k, v.replaceAll("\\s+", " ").trim)
+        }
         .filter { case (_, v) => v.nonEmpty }
       if (logger.underlying.isDebugEnabled) logger.debug(solrFields
         .map { case (key, value) => s"$key = $value" }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -45,6 +45,7 @@ trait Solr extends DebugEnhancedLogging {
   def createDoc(item: FileItem): Try[FileFeedback] = {
     item.bag.fileUrl(item.path).flatMap { fileUrl =>
       val solrDocId = s"${ item.bag.bagId }/${ item.path }"
+      // TODO only normalise whitespace for item.ddm.solrLiterals and then only trim all values
       val solrFields = (item.bag.solrLiterals ++ item.ddm.solrLiterals ++ item.solrLiterals :+ "file_size" -> item.size.toString)
         .map {
           case (k, v) if k == "file_path" => (k, v.trim) // do not normalise whitespace in filepath


### PR DESCRIPTION
Fixes removal of whitespaces in the indexed file_path

#### When applied it will
* Skip whitspace normalisation for the file_path field

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
index a bag (deposit) with a file that has multiple adjacent spaces

check that the 'easy_file_path' files contains all the whitespaces. 

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..