### PR TITLE
NO JIRA: configurable file size limit, added file title to solr literals

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -9,3 +9,6 @@ ldap.provider.url=ldap://localhost
 # TODO: this is not actually a "reasonable default", as it is DANS-specific, so it should be replaced by something like 'ou=users, dc=yourdomain-here, dc=org'
 # TODO: However that will require some extra work on the local test-vm
 ldap.users-entry=ou=users,ou=easy,dc=dans,dc=knaw,dc=nl
+
+# 64*1024*1024
+max-fileSize-toExtract-content-from=67108864

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
@@ -40,5 +40,5 @@ trait ApplicationWiring
   // don't need resolve for solr, URL gives more early errors TODO perhaps not yet at service startup once implemented
   override val solrUrl: URL = new URL(properties.getString("solr.url", "http://localhost"))
   override val vaultBaseUri: URI = new URI(properties.getString("vault.url", "http://localhost"))
-
+  override val maxFileSizeToExtractContentFrom: Double = properties.getString("max-fileSize-toExtract-content-from", (64*1024*1024).toString).toDouble
 }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/FileItem.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/FileItem.scala
@@ -49,20 +49,16 @@ case class FileItem(bag: Bag, ddm: DDM, xml: Node) extends DebugEnhancedLogging 
 
   lazy val size: Long = bag.fileSize(path)
 
-  val shouldSubmitWithContent: Boolean = {
-    // prevent content submission and extraction for large files, to keep it fast
-    // TODO make this value configurable
-    val maxFileSizeToExtractContentFrom = 64*1024*1024
-    size <= maxFileSizeToExtractContentFrom
-  }
-
   val mimeType: String = (xml \ "format").text
+  val title: String = (xml \ "title").text
 
   // lazy postpones loading Bag.sha's
   lazy val solrLiterals: SolrLiterals = Seq(
     ("file_path", path),
+    ("file_title", title),
     ("file_checksum", bag.sha(path)),
     ("file_mime_type", mimeType),
+    ("file_size", size.toString),
     ("file_accessible_to", accessibleTo)
   )
 }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -37,18 +37,19 @@ import scala.util.{ Failure, Success, Try }
 
 trait Solr extends DebugEnhancedLogging {
   val solrUrl: URL
+  val maxFileSizeToExtractContentFrom: Double
   lazy val solrClient: SolrClient = new HttpSolrClient.Builder(solrUrl.toString).build()
 
   def createDoc(item: FileItem): Try[FileFeedback] = {
     item.bag.fileUrl(item.path).flatMap { fileUrl =>
       val solrDocId = s"${ item.bag.bagId }/${ item.path }"
-      val solrFields = (item.bag.solrLiterals ++ item.ddm.solrLiterals ++ item.solrLiterals :+ "file_size" -> item.size.toString)
+      val solrFields = (item.bag.solrLiterals ++ item.ddm.solrLiterals ++ item.solrLiterals)
         .filter { case (_, v) => v.nonEmpty }
       if (logger.underlying.isDebugEnabled) logger.debug(solrFields
         .map { case (key, value) => s"$key = $value" }
         .mkString("\n\t")
       )
-      if (!item.shouldSubmitWithContent) {
+      if (item.size > maxFileSizeToExtractContentFrom) {
         logger.info(s"Submission without content of [$solrDocId]")
         submitWithOnlyMetadata(solrDocId, solrFields).map(_ => FileSubmittedWithOnlyMetadata(solrDocId))
       }

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -9,3 +9,6 @@ ldap.provider.url=ldap://deasy.dans.knaw.nl:389
 # TODO: this is not actually a "reasonable default", as it is DANS-specific, so it should be replaced by something like 'ou=users, dc=yourdomain-here, dc=org'
 # TODO: However that will require some extra work on the local test-vm
 ldap.users-entry=ou=users,ou=easy,dc=dans,dc=knaw,dc=nl
+
+# 64*1024*1024
+max-fileSize-toExtract-content-from=67108864

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/components/FileItemSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/components/FileItemSpec.scala
@@ -38,6 +38,8 @@ class FileItemSpec extends TestSupportFixture {
 
     val solrLiterals = fi.solrLiterals.toMap
     solrLiterals("file_path") shouldBe fi.path
+    solrLiterals("file_size") shouldBe "0"
+    solrLiterals("file_title") shouldBe "video about the centaur meteorite"
     solrLiterals("file_accessible_to") shouldBe "RESTRICTED_GROUP"
     solrLiterals("file_mime_type") shouldBe "video/mpeg"
     solrLiterals("file_checksum") shouldBe "1dd40013ce63dfa98dfe19f5b4bbf811ee2240f7"


### PR DESCRIPTION
Fixed TODO added by #13 

#### When applied it will
* have a  configurable file size limit, if omitted the currently hard-coded value is used as default
* added file size to the solr literals in the same way as the other file properties
* added the file title to the solr literals

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* [x] see #16

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | further TODO's to fix soon also
