### PR TITLE
EASY-1401 preparation : follow conventions of easy-download / easy-auth-info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,11 @@
             <groupId>org.joda</groupId>
             <artifactId>joda-convert</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>20.0</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
@@ -15,11 +15,8 @@
  */
 package nl.knaw.dans.easy.solr4files
 
-import java.net.{ URI, URL }
-
 import nl.knaw.dans.easy.solr4files.components._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import org.apache.commons.configuration.PropertiesConfiguration
 
 /**
  * Initializes and wires together the components of this application.
@@ -29,16 +26,4 @@ trait ApplicationWiring
     with Vault
     with Solr
     with AuthenticationComponent {
-
-  val configuration: Configuration
-  private val properties: PropertiesConfiguration = Option(configuration).map(_.properties).getOrElse(new PropertiesConfiguration())
-  override val authentication: Authentication = new Authentication {
-    override val ldapUsersEntry: String = properties.getString("ldap.users-entry")
-    override val ldapProviderUrl: String = properties.getString("ldap.provider.url")
-  }
-
-  // don't need resolve for solr, URL gives more early errors TODO perhaps not yet at service startup once implemented
-  override val solrUrl: URL = new URL(properties.getString("solr.url", "http://localhost"))
-  override val vaultBaseUri: URI = new URI(properties.getString("vault.url", "http://localhost"))
-  override val maxFileSizeToExtractContentFrom: Double = properties.getString("max-fileSize-toExtract-content-from", (64*1024*1024).toString).toDouble
 }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -36,9 +36,8 @@ import scala.language.postfixOps
 import scala.util.{ Failure, Success, Try }
 
 trait Solr extends DebugEnhancedLogging {
-  val solrUrl: URL
   val maxFileSizeToExtractContentFrom: Double
-  lazy val solrClient: SolrClient = new HttpSolrClient.Builder(solrUrl.toString).build()
+  val solrClient: SolrClient
 
   def createDoc(item: FileItem): Try[FileFeedback] = {
     item.bag.fileUrl(item.path).flatMap { fileUrl =>

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Vault.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Vault.scala
@@ -51,7 +51,7 @@ trait Vault extends DebugEnhancedLogging {
   }
 
   def fileURL(storeName: String, bagId: UUID, file: String): Try[URL] = Try {
-    val f = URLEncoder.encode(file, "UTF8")
+    val f = escapePath(Paths.get(file))
     vaultBaseUri.resolve(s"stores/$storeName/bags/$bagId/$f").toURL
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
@@ -15,9 +15,11 @@
  */
 package nl.knaw.dans.easy
 
-import java.io.File
+import java.io.{ File, OutputStream }
 import java.net.{ URL, URLDecoder }
+import java.nio.file.Path
 
+import com.google.common.net.UrlEscapers
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.io.FileUtils.readFileToString
@@ -26,16 +28,23 @@ import org.scalatra
 
 import scala.annotation.tailrec
 import scala.collection.mutable
+import scala.collection.JavaConverters._
 import scala.util.{ Failure, Success, Try }
 import scala.xml.{ Elem, Node, XML }
 import scalaj.http.{ Http, HttpResponse }
 
 package object solr4files extends DebugEnhancedLogging {
+  private val pathEscaper = UrlEscapers.urlPathSegmentEscaper()
 
   type FeedBackMessage = String
   type SolrLiterals = Seq[(String, String)]
   type FileToShaMap = Map[String, String]
   type VocabularyMap = Map[String, String]
+  type OutputStreamProvider = () => OutputStream
+
+  def escapePath(path: Path): String = {
+    path.asScala.map(_.toString).map(pathEscaper.escape).mkString("/")
+  }
 
   case class HttpStatusException(msg: String, response: HttpResponse[String])
     extends Exception(s"$msg - ${ response.statusLine }, details: ${ response.body }")

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/SearchServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/SearchServletSpec.scala
@@ -31,10 +31,8 @@ class SearchServletSpec extends TestSupportFixture
   with ScalatraSuite
   with MockFactory {
 
-  private class StubbedApp extends EasySolr4filesIndexApp() {
-    override lazy val configuration: Configuration = configWithMockedVault
-
-    override lazy val solrClient: SolrClient = new SolrClient() {
+  private val testApp = new TestApp() {
+    override val solrClient: SolrClient = new SolrClient() {
       // can't use mock because SolrClient has a final method
 
       override def query(params: SolrParams): QueryResponse = mockQueryResponse(params)
@@ -69,7 +67,7 @@ class SearchServletSpec extends TestSupportFixture
     }
   }
 
-  addServlet(new SearchServlet(new StubbedApp), "/*")
+  addServlet(new SearchServlet(testApp), "/*")
 
   "get /" should "translate to searching with *:* and the default parser" in {
     get("/?q=foo+bar") { // q is ignored as it is an unknown argument

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
@@ -28,10 +28,8 @@ class SolrErrorHandlingSpec extends TestSupportFixture
   with ServletFixture
   with ScalatraSuite {
 
-  private class StubbedApp extends EasySolr4filesIndexApp() {
-    override lazy val configuration: Configuration = configWithMockedVault
-
-    override lazy val solrClient: SolrClient = new SolrClient() {
+  private val app = new TestApp() {
+    override val solrClient: SolrClient = new SolrClient() {
       // can't use mock because SolrClient has a final method
 
       override def deleteByQuery(q: String): UpdateResponse = q match {
@@ -62,8 +60,6 @@ class SolrErrorHandlingSpec extends TestSupportFixture
       }
     }
   }
-
-  private val app = new StubbedApp
   addServlet(new UpdateServlet(app), "/fileindex/*")
   addServlet(new SearchServlet(app), "/filesearch/*")
 

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/TestSupportFixture.scala
@@ -21,7 +21,6 @@ import java.nio.file.{ Files, Path, Paths }
 import java.util.UUID
 
 import nl.knaw.dans.easy.solr4files.components.Vault
-import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.commons.io.FileUtils
 import org.scalatest.{ BeforeAndAfterEach, FlatSpec, Inside, Matchers }
 
@@ -36,6 +35,16 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
     path
   }
 
+  abstract class TestApp() extends EasySolr4filesIndexApp {
+
+    override val maxFileSizeToExtractContentFrom: Double = 64 * 1024 * 1024
+    override val vaultBaseUri: URI = new URI(s"file:///${ testDir.resolve("vault").toAbsolutePath }/")
+    override val authentication: Authentication = new Authentication {
+      override val ldapUsersEntry: String = "ou=users,ou=easy,dc=dans,dc=knaw,dc=nl"
+      override val ldapProviderUrl: String = "ldap://hostThatDoesNotExist:389"
+    }
+  }
+
   val uuidCentaur: UUID = UUID.fromString("9da0541a-d2c8-432e-8129-979a9830b427")
   val uuidAnonymized: UUID = UUID.fromString("1afcc4e9-2130-46cc-8faf-2663e199b218")
 
@@ -43,15 +52,6 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
     // vault/stores is sometimes a folder, sometimes a dir
     private val vaultBaseDir = URLEncoder.encode(testDir.resolve("vault").toAbsolutePath.toString, "UTF8")
     override val vaultBaseUri = new URI(s"file:///$vaultBaseDir/")
-  }
-
-  val configWithMockedVault: Configuration = {
-    new Configuration("", new PropertiesConfiguration() {
-      addProperty("solr.url", "http://deasy.dans.knaw.nl:8983/solr/easyfiles")
-      addProperty("vault.url", mockedVault.vaultBaseUri.toURL.toString)
-      addProperty("ldap.users-entry", "ou=users,ou=easy,dc=dans,dc=knaw,dc=nl")
-      addProperty("ldap.provider.url", "ldap://localhost:389")
-    })
   }
 
   def clearVault(): Unit = {

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
@@ -29,10 +29,7 @@ class UpdateServletSpec extends TestSupportFixture
   with ScalatraSuite
   with MockFactory {
 
-  private class App extends EasySolr4filesIndexApp() {
-    override lazy val configuration: Configuration = configWithMockedVault
-  }
-  private val app = mock[EasySolr4filesIndexApp]
+  private val app = mock[TestApp]
   addServlet(new UpdateServlet(app), "/*")
 
   private val uuid = UUID.randomUUID()


### PR DESCRIPTION
Prepares for EASY-1401

#### When applied it will
* apply guava to encode file paths
* have App/Wiring turned into traits (this prepares to use AUTH-INFO in stead of duplicating the logic)
* prepares for https://drivenbydata.atlassian.net/browse/EASY-1401 (use easy-authinfo, the current code duplication ignores \<dcterms:AccessRights\> which should be treated as \<accessibleToRights\>)

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

See #16 

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
