### PR TITLE
EASY-1496 File content indexing of images fails because of timestamp formats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 language: java
 jdk: oraclejdk8
+cache:
+  directories:
+    - "$HOME/.m2/repository"

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -20,4 +20,5 @@ file-content-extraction.mime-types=\
   text/plain, \
   text/xml, \
   text/html, \
+  application/pdf \
   application/vnd.openxmlformats-officedocument.wordprocessingml.document

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -11,8 +11,11 @@ ldap.provider.url=ldap://localhost
 # TODO: However that will require some extra work on the local test-vm
 ldap.users-entry=ou=users,ou=easy,dc=dans,dc=knaw,dc=nl
 
-# 64*1024*1024
-max-fileSize-toExtract-content-from=67108864
+#
+# The service will try to have Solr index extracted content from the file. This is limited to the
+# media types and file size configured below.
+#
+file-content-extraction.max-filesize=67108864
 file-content-extraction.mime-types=\
   text/plain, \
   text/xml, \

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -13,4 +13,8 @@ ldap.users-entry=ou=users,ou=easy,dc=dans,dc=knaw,dc=nl
 
 # 64*1024*1024
 max-fileSize-toExtract-content-from=67108864
-file-content-extraction.mime-types=text/plain, application/pdf, application/vnd.openxmlformats-officedocument.wordprocessingml.document, text/xml
+file-content-extraction.mime-types=\
+  text/plain, \
+  text/xml, \
+  text/html, \
+  application/vnd.openxmlformats-officedocument.wordprocessingml.document

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -13,3 +13,4 @@ ldap.users-entry=ou=users,ou=easy,dc=dans,dc=knaw,dc=nl
 
 # 64*1024*1024
 max-fileSize-toExtract-content-from=67108864
+file-content-extraction.mime-types=text/plain, application/pdf, application/vnd.openxmlformats-officedocument.wordprocessingml.document, text/xml

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
@@ -49,5 +49,8 @@ trait ApplicationWiring
   override val solrClient: SolrClient = new HttpSolrClient.Builder(solrUrl.toString).build()
   override val vaultBaseUri: URI = new URI(configuration.properties.getString("vault.url", "http://localhost"))
   //TODO BagStoreComponent using HttpWorker as in easy-download
+
+  // Cannot use properties.getList in the following line because we do not parse commas. Parsing commas conflicts with having LDAP DNs as values.
+  override val mimeTypesToExtractContentFrom: Seq[String] = configuration.properties.getString("file-content-extraction.mime-types", "").split(Array(' ', ','))
   override val maxFileSizeToExtractContentFrom: Double = configuration.properties.getString("max-fileSize-toExtract-content-from", (64 * 1024 * 1024).toString).toDouble
 }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
@@ -52,5 +52,5 @@ trait ApplicationWiring
 
   // Cannot use properties.getList in the following line because we do not parse commas. Parsing commas conflicts with having LDAP DNs as values.
   override val mimeTypesToExtractContentFrom: Seq[String] = configuration.properties.getString("file-content-extraction.mime-types", "").split(Array(' ', ','))
-  override val maxFileSizeToExtractContentFrom: Double = configuration.properties.getString("max-fileSize-toExtract-content-from", (64 * 1024 * 1024).toString).toDouble
+  override val maxFileSizeToExtractContentFrom: Double = configuration.properties.getString("file-content-extraction.max-filesize", (64 * 1024 * 1024).toString).toDouble
 }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/EasySolr4filesIndexApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/EasySolr4filesIndexApp.scala
@@ -120,11 +120,13 @@ trait EasySolr4filesIndexApp extends ApplicationWiring with AutoCloseable
   }
 
   private def getFileItem(bag: Bag, fileNode: Node): Option[Try[FileItem]] = {
+    val title = (fileNode \ "title").text
+    val mimeType = (fileNode \ "format").text
     getAccessibleAuthInfo(bag.bagId, fileNode) match {
       case None => Some(Failure(new Exception(s"invalid files.xml for ${ bag.bagId }: filepath attribute is missing in ${ fileNode.toString().toOneLiner }")))
       case Some(Failure(t)) => Some(Failure(t))
       case Some(Success(authInfoItem)) if !authInfoItem.isAccessible => None
-      case Some(Success(authInfoItem)) => Some(Success(FileItem(bag, fileNode, authInfoItem)))
+      case Some(Success(authInfoItem)) => Some(Success(FileItem(bag, title, mimeType , authInfoItem)))
     }
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/FileItem.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/FileItem.scala
@@ -20,7 +20,7 @@ import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 import scala.xml.Node
 
-case class FileItem(bag: Bag, xml: Node, authInfoItem: AuthorisationItem) extends DebugEnhancedLogging {
+case class FileItem(bag: Bag, title: String, mimeType: String, authInfoItem: AuthorisationItem) extends DebugEnhancedLogging {
 
   //strip the UUID from the itemId including the first slash
   val path: String = authInfoItem.itemId.replaceAll("^[^/]+/", "")
@@ -30,9 +30,9 @@ case class FileItem(bag: Bag, xml: Node, authInfoItem: AuthorisationItem) extend
   // lazy postpones loading Bag.sha's
   lazy val solrLiterals: SolrLiterals = Seq(
     ("file_path", path),
-    ("file_title", (xml \ "title").text),
+    ("file_title", title),
     ("file_checksum", bag.sha(path)),
-    ("file_mime_type", (xml \ "format").text),
+    ("file_mime_type", mimeType),
     ("file_size", size.toString),
     ("file_accessible_to", authInfoItem.accessibleTo.toString),
     ("dataset_depositor_id", authInfoItem.owner),

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -56,7 +56,7 @@ trait Solr extends DebugEnhancedLogging {
         .mkString("\n\t")
       )
     }
-    val fileSizeOkForIndexing = maxFileSizeToExtractContentFrom < item.size
+    val fileSizeOkForIndexing = maxFileSizeToExtractContentFrom > item.size
     val fileMimeTypeEligibleForIndexing = mimeTypesToExtractContentFrom.contains(item.mimeType)
     if (fileSizeOkForIndexing && fileMimeTypeEligibleForIndexing) {
       logger.info(s"Submission with content of [$solrDocId]")

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -63,7 +63,7 @@ trait Solr extends DebugEnhancedLogging {
       submitWithContent(fileUrl, solrDocId, solrLiterals)
         .map(_ => FileSubmittedWithContent(solrDocId))
         .recoverWith { case t =>
-          logger.warn(s"Submission with content of [$solrDocId] failed. Proceeding to index only metadata. Message for Solr: ${ t.getMessage }")
+          logger.warn(s"Submission with content of [$solrDocId] failed. Proceeding to index only metadata. Message from Solr: ${ t.getMessage }")
           submitWithOnlyMetadata(solrDocId, solrLiterals).map(_ => FileSubmittedWithOnlyMetadata(solrDocId))
         }
     }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -36,6 +36,7 @@ import scala.language.postfixOps
 import scala.util.{ Failure, Success, Try }
 
 trait Solr extends DebugEnhancedLogging {
+  val mimeTypesToExtractContentFrom: Seq[String]
   val maxFileSizeToExtractContentFrom: Double
   val solrClient: SolrClient
 
@@ -55,18 +56,20 @@ trait Solr extends DebugEnhancedLogging {
         .mkString("\n\t")
       )
     }
-    if (item.size > maxFileSizeToExtractContentFrom) {
-      logger.info(s"Submission without content of [$solrDocId]")
-      submitWithOnlyMetadata(solrDocId, solrLiterals).map(_ => FileSubmittedWithOnlyMetadata(solrDocId))
-    }
-    else {
+    val fileSizeOkForIndexing = maxFileSizeToExtractContentFrom < item.size
+    val fileMimeTypeEligibleForIndexing = mimeTypesToExtractContentFrom.contains(item.mimeType)
+    if (fileSizeOkForIndexing && fileMimeTypeEligibleForIndexing) {
       logger.info(s"Submission with content of [$solrDocId]")
       submitWithContent(fileUrl, solrDocId, solrLiterals)
         .map(_ => FileSubmittedWithContent(solrDocId))
         .recoverWith { case t =>
-          logger.warn(s"Submission with content of [$solrDocId] failed with ${ t.getMessage }")
+          logger.warn(s"Submission with content of [$solrDocId] failed. Proceeding to index only metadata. Message for Solr: ${ t.getMessage }")
           submitWithOnlyMetadata(solrDocId, solrLiterals).map(_ => FileSubmittedWithOnlyMetadata(solrDocId))
         }
+    }
+    else {
+      logger.info(s"Submission without content of [$solrDocId] (file size OK for extraction = $fileSizeOkForIndexing, MIME-Type eligible = $fileMimeTypeEligibleForIndexing)")
+      submitWithOnlyMetadata(solrDocId, solrLiterals).map(_ => FileSubmittedWithOnlyMetadata(solrDocId))
     }
   }
 

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -12,5 +12,5 @@ ldap.provider.url=ldap://deasy.dans.knaw.nl:389
 ldap.users-entry=ou=users,ou=easy,dc=dans,dc=knaw,dc=nl
 
 # 64*1024*1024
-max-fileSize-toExtract-content-from=67108864
+file-content-extraction.max-filesize=67108864
 file-content-extraction.mime-types=text/plain, application/pdf

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -13,3 +13,4 @@ ldap.users-entry=ou=users,ou=easy,dc=dans,dc=knaw,dc=nl
 
 # 64*1024*1024
 max-fileSize-toExtract-content-from=67108864
+file-content-extraction.mime-types=text/plain, application/pdf

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -13,4 +13,9 @@ ldap.users-entry=ou=users,ou=easy,dc=dans,dc=knaw,dc=nl
 
 # 64*1024*1024
 file-content-extraction.max-filesize=67108864
-file-content-extraction.mime-types=text/plain, application/pdf
+file-content-extraction.mime-types=\
+  text/plain, \
+  text/xml, \
+  text/html, \
+  application/pdf \
+  application/vnd.openxmlformats-officedocument.wordprocessingml.document

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/AppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/AppSpec.scala
@@ -90,9 +90,9 @@ class AppSpec extends TestSupportFixture {
     val app = new StubbedSolrApp()
     Seq(
       "data/path/to/a/random/video/hubble.mpg",
+      "data/reisverslag/centaur-nederlands.srt",
       "data/reisverslag/centaur.mpg",
       "data/reisverslag/centaur.srt",
-      "data/reisverslag/centaur-nederlands.srt",
       "data/reisverslag/deel01.docx",
       "data/reisverslag/deel01.txt",
       "data/reisverslag/deel02.txt",
@@ -127,7 +127,7 @@ class AppSpec extends TestSupportFixture {
 
     val result = app.update(storeName, uuidAnonymized)
     inside(result) { case Success(feedback) =>
-      feedback.toString shouldBe s"Bag ${ uuidAnonymized }: 3 times FileSubmittedWithContent"
+      feedback.toString shouldBe s"Bag ${ uuidAnonymized }: 2 times FileSubmittedWithContent, 1 times FileSubmittedWithOnlyMetadata"
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/TestSupportFixture.scala
@@ -46,6 +46,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
     })
 
     override val maxFileSizeToExtractContentFrom: Double = 64 * 1024 * 1024
+    override val mimeTypesToExtractContentFrom: Seq[String] = Seq("text/plain", "application/pdf", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "text/xml")
     override val vaultBaseUri: URI = new URI(s"file:///${ testDir.resolve("vault").toAbsolutePath }/")
     override val authentication: Authentication = new Authentication {
       override val ldapUsersEntry: String = "ou=users,ou=easy,dc=dans,dc=knaw,dc=nl"

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/components/FileItemSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/components/FileItemSpec.scala
@@ -49,7 +49,7 @@ class FileItemSpec extends TestSupportFixture {
       accessibleTo = RESTRICTED_GROUP,
       visibleTo = RESTRICTED_GROUP
     )
-    val solrLiterals = FileItem(mockedBag, xml, authInfoItem).solrLiterals.toMap
+    val solrLiterals = FileItem(mockedBag, (xml \ "title").text, (xml \ "format").text , authInfoItem).solrLiterals.toMap
     solrLiterals("file_path") shouldBe filePath
     solrLiterals("file_size") shouldBe s"$fileSize"
     solrLiterals("file_title") shouldBe "video about the centaur meteorite"


### PR DESCRIPTION
Fixes EASY-1496

#### When applied it will
* Make the mime types for which to attempt content extraction configurable.

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github


To do:
- [x] Fix unit tests
- [x] Test in `easy-dtap`
- [x] Refactor setting names
- [x] Document settings