### PR TITLE
EASY-1739: add timeout configuration for easy-auth-info call

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -5,6 +5,8 @@ solr4files.daemon.http.port=20150
 vault.url=http://localhost:20110/
 solr.url=http://localhost:8983/solr/fileitems/
 auth-info.url=http://localhost:20170/
+auth-info.connection-timeout-ms=2000
+auth-info.read-timeout-ms=2000
 
 ldap.provider.url=ldap://localhost
 # TODO: this is not actually a "reasonable default", as it is DANS-specific, so it should be replaced by something like 'ou=users, dc=yourdomain-here, dc=org'

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
@@ -41,8 +41,8 @@ trait ApplicationWiring
   }
   override val authorisation: Authorisation = new Authorisation {
     override val baseUri: URI = new URI(configuration.properties.getString("auth-info.url"))
-    override val connectionTimeOut: Int = configuration.properties.getInt("auth-info.connection-timeout-ms")
-    override val readTimeOut: Int = configuration.properties.getInt("auth-info.read-timeout-ms")
+    override val connectionTimeOutMs: Int = configuration.properties.getInt("auth-info.connection-timeout-ms")
+    override val readTimeOutMs: Int = configuration.properties.getInt("auth-info.read-timeout-ms")
   }
   override val http: HttpWorker = new HttpWorker {}
 

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
@@ -41,6 +41,8 @@ trait ApplicationWiring
   }
   override val authorisation: Authorisation = new Authorisation {
     override val baseUri: URI = new URI(configuration.properties.getString("auth-info.url"))
+    override val connectionTimeOut: Int = configuration.properties.getInt("auth-info.connection-timeout-ms")
+    override val readTimeOut: Int = configuration.properties.getInt("auth-info.read-timeout-ms")
   }
   override val http: HttpWorker = new HttpWorker {}
 

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/AuthorisationComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/AuthorisationComponent.scala
@@ -32,15 +32,15 @@ trait AuthorisationComponent extends DebugEnhancedLogging {
 
   trait Authorisation {
     val baseUri: URI
-    val connectionTimeOut: Int // ms
-    val readTimeOut: Int // ms
+    val connectionTimeOutMs: Int
+    val readTimeOutMs: Int
 
     private implicit val jsonFormats: Formats = DefaultFormats
 
     def getAuthInfoItem(bagId: UUID, path: Path): Try[AuthorisationItem] = {
       val uri = baseUri.resolve(s"$bagId/${ escapePath(path) }")
       for {
-        jsonString <- http.getHttpAsString(uri, connectionTimeOut, readTimeOut)
+        jsonString <- http.getHttpAsString(uri, connectionTimeOutMs, readTimeOutMs)
         jsonOneLiner = jsonString.toOneLiner
         _ = logger.debug(s"auth-info: ${ jsonOneLiner }")
         authInfoItem <- AuthorisationItem.fromJson(jsonOneLiner)

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/AuthorisationComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/AuthorisationComponent.scala
@@ -32,13 +32,15 @@ trait AuthorisationComponent extends DebugEnhancedLogging {
 
   trait Authorisation {
     val baseUri: URI
+    val connectionTimeOut: Int // ms
+    val readTimeOut: Int // ms
 
     private implicit val jsonFormats: Formats = DefaultFormats
 
     def getAuthInfoItem(bagId: UUID, path: Path): Try[AuthorisationItem] = {
       val uri = baseUri.resolve(s"$bagId/${ escapePath(path) }")
       for {
-        jsonString <- http.getHttpAsString(uri)
+        jsonString <- http.getHttpAsString(uri, connectionTimeOut, readTimeOut)
         jsonOneLiner = jsonString.toOneLiner
         _ = logger.debug(s"auth-info: ${ jsonOneLiner }")
         authInfoItem <- AuthorisationItem.fromJson(jsonOneLiner)

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/HttpWorkerComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/HttpWorkerComponent.scala
@@ -38,8 +38,12 @@ trait HttpWorkerComponent {
       else failed(uri, response)
     }
 
-    def getHttpAsString(uri: URI): Try[String] = {
-      val response = Http(uri.toString).method("GET").asString
+    def getHttpAsString(uri: URI, connTimeoutMs: Int, readTimeoutMs: Int): Try[String] = {
+      val response = Http(uri.toString)
+        .method("GET")
+        .timeout(connTimeoutMs, readTimeoutMs)
+        .asString
+
       if (response.isSuccess) Success(response.body)
       else failed(uri, response)
     }

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -5,6 +5,8 @@ solr4files.daemon.http.port=20150
 vault.url=http://deasy.dans.knaw.nl:20110/
 solr.url=http://deasy.dans.knaw.nl:8983/solr/fileitems/
 auth-info.url=http://deasy.dans.knaw.nl:20170/
+auth-info.connection-timeout-ms=2000
+auth-info.read-timeout-ms=2000
 
 ldap.provider.url=ldap://deasy.dans.knaw.nl:389
 # TODO: this is not actually a "reasonable default", as it is DANS-specific, so it should be replaced by something like 'ou=users, dc=yourdomain-here, dc=org'

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/TestSupportFixture.scala
@@ -56,8 +56,8 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
     }
     override val authorisation: Authorisation = new Authorisation {
       override val baseUri: URI = new URI("http://authInfoHostDoesNotExist:20170/")
-      override val connectionTimeOut: Int = 2000
-      override val readTimeOut: Int = 2000
+      override val connectionTimeOutMs: Int = 2000
+      override val readTimeOutMs: Int = 2000
     }
     override val http: HttpWorker = mock[HttpWorker]
 

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/TestSupportFixture.scala
@@ -23,7 +23,7 @@ import java.util.UUID
 import nl.knaw.dans.easy.solr4files.components.Vault
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.commons.io.FileUtils
-import org.scalamock.handlers.CallHandler1
+import org.scalamock.handlers.CallHandler3
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{ BeforeAndAfterEach, FlatSpec, Inside, Matchers }
 
@@ -43,6 +43,8 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
 
     override lazy val configuration: Configuration = new Configuration("", new PropertiesConfiguration() {
       addProperty("auth-info.url", "http://hostThatDoesNotExist:20170/")
+      addProperty("auth-info.connection-timeout-ms", 2000)
+      addProperty("auth-info.read-timeout-ms", 2000)
     })
 
     override val maxFileSizeToExtractContentFrom: Double = 64 * 1024 * 1024
@@ -54,11 +56,13 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
     }
     override val authorisation: Authorisation = new Authorisation {
       override val baseUri: URI = new URI("http://authInfoHostDoesNotExist:20170/")
+      override val connectionTimeOut: Int = 2000
+      override val readTimeOut: Int = 2000
     }
     override val http: HttpWorker = mock[HttpWorker]
 
-    def expectsHttpAsString(result: Try[String]): CallHandler1[URI, Try[String]] = {
-      (http.getHttpAsString(_: URI)) expects * returning result
+    def expectsHttpAsString(result: Try[String]): CallHandler3[URI, Int, Int, Try[String]] = {
+      (http.getHttpAsString(_: URI, _: Int, _: Int)) expects (*, *, *) returning result
     }
   }
 


### PR DESCRIPTION
Fixes EASY-1739

#### When applied it will
* add timeout configuration for easy-auth-info call

@DANS-KNAW/easy for review

See also https://github.com/DANS-KNAW/easy-dtap/pull/251