### PR TITLE
EASY-1670 Command-line startup script: argumenten met spaties

### DIFF
--- a/src/main/assembly/dist/bin/easy-solr4files-index
+++ b/src/main/assembly/dist/bin/easy-solr4files-index
@@ -18,4 +18,4 @@ fi
 LC_ALL=en_US.UTF-8 \
 java -Dlogback.configurationFile=$LOGBACK_CFG \
      -Dapp.home=$APPHOME \
-     -jar $APPHOME/bin/$MODULE.jar $@
+     -jar $APPHOME/bin/$MODULE.jar "$@"


### PR DESCRIPTION
Fixes EASY-1670

#### When applied
* It is possible to pass parameters containing spaces


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
