### PR TITLE
EASY-2002: add service is running and version to baseurl

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.solr4files/EasySolr4FilesServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/EasySolr4FilesServlet.scala
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.solr4files
+
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.lib.logging.servlet._
+import org.scalatra._
+
+class EasySolr4FilesServlet(app: EasySolr4filesIndexApp) extends ScalatraServlet
+  with ServletLogger
+  with PlainLogFormatter
+  with DebugEnhancedLogging {
+  logger.info("File index Servlet running...")
+
+  get("/") {
+    contentType = "text/plain"
+    Ok(s"EASY File Index is running v${app.configuration.version}.").logResponse
+  }
+}

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/EasySolr4filesIndexService.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/EasySolr4filesIndexService.scala
@@ -33,6 +33,7 @@ class EasySolr4filesIndexService(val serverPort: Int, app: EasySolr4filesIndexAp
         override def probeForCycleClass(classLoader: ClassLoader): (String, LifeCycle) = {
           ("Solr4files-lifecycle", new LifeCycle {
             override def init(context: ServletContext): Unit = {
+              context.mount(new EasySolr4FilesServlet(app), "/")
               context.mount(new UpdateServlet(app), "/fileindex")
               context.mount(new SearchServlet(app), "/filesearch")
             }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/UpdateServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/UpdateServlet.scala
@@ -32,11 +32,6 @@ class UpdateServlet(app: EasySolr4filesIndexApp) extends ScalatraServlet
   with DebugEnhancedLogging {
   logger.info("File index Servlet running...")
 
-  get("/") {
-    contentType = "text/plain"
-    Ok(s"EASY File Index is running v${ app.configuration.version }.").logResponse //TODO does this need to be in the update servlet?
-  }
-
   private def respond(result: Try[String]): ActionResult = {
     val msgPrefix = "Log files should show which actions succeeded. Finally failed with: "
     result.map(Ok(_))

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/UpdateServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/UpdateServlet.scala
@@ -34,7 +34,7 @@ class UpdateServlet(app: EasySolr4filesIndexApp) extends ScalatraServlet
 
   get("/") {
     contentType = "text/plain"
-    Ok("EASY File Index is running.").logResponse
+    Ok(s"EASY File Index is running v${ app.configuration.version }.").logResponse //TODO does this need to be in the update servlet?
   }
 
   private def respond(result: Try[String]): ActionResult = {

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/EasySolr4FilesServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/EasySolr4FilesServletSpec.scala
@@ -26,7 +26,7 @@ class EasySolr4FilesServletSpec extends TestSupportFixture
   with MockFactory {
 
   private val app = mock[TestApp]
-  addServlet(new UpdateServlet(app), "/")
+  addServlet(new EasySolr4FilesServlet(app), "/")
 
   "get /" should "return a 200 stating the service is running and the version number" in {
     get("/") {

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/EasySolr4FilesServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/EasySolr4FilesServletSpec.scala
@@ -15,10 +15,10 @@
  */
 package nl.knaw.dans.easy.solr4files
 
+import org.apache.http.HttpStatus._
 import org.scalamock.scalatest.MockFactory
 import org.scalatra.test.EmbeddedJettyContainer
 import org.scalatra.test.scalatest.ScalatraSuite
-import org.apache.http.HttpStatus._
 
 class EasySolr4FilesServletSpec extends TestSupportFixture
   with EmbeddedJettyContainer

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/EasySolr4FilesServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/EasySolr4FilesServletSpec.scala
@@ -27,10 +27,11 @@ class EasySolr4FilesServletSpec extends TestSupportFixture
 
   private val app = mock[TestApp]
   addServlet(new EasySolr4FilesServlet(app), "/")
+  private val testVersion = "1.0.0"
 
   "get /" should "return a 200 stating the service is running and the version number" in {
     get("/") {
-      body shouldBe s"EASY File Index is running v${ app.configuration.version }." //app.configuration.version is empty
+      body shouldBe s"EASY File Index is running v$testVersion."
       status shouldBe SC_OK
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/EasySolr4FilesServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/EasySolr4FilesServletSpec.scala
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.solr4files
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatra.test.EmbeddedJettyContainer
+import org.scalatra.test.scalatest.ScalatraSuite
+import org.apache.http.HttpStatus._
+
+class EasySolr4FilesServletSpec extends TestSupportFixture
+  with EmbeddedJettyContainer
+  with ScalatraSuite
+  with MockFactory {
+
+  private val app = mock[TestApp]
+  addServlet(new UpdateServlet(app), "/")
+
+  "get /" should "return a 200 stating the service is running and the version number" in {
+    get("/") {
+      body shouldBe s"EASY File Index is running v${ app.configuration.version }." //app.configuration.version is empty
+      status shouldBe SC_OK
+    }
+  }
+}

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/TestSupportFixture.scala
@@ -62,7 +62,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
     override val http: HttpWorker = mock[HttpWorker]
 
     def expectsHttpAsString(result: Try[String]): CallHandler3[URI, Int, Int, Try[String]] = {
-      (http.getHttpAsString(_: URI, _: Int, _: Int)) expects (*, *, *) returning result
+      (http.getHttpAsString(_: URI, _: Int, _: Int)) expects(*, *, *) returning result
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/TestSupportFixture.scala
@@ -41,7 +41,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
 
   abstract class TestApp() extends EasySolr4filesIndexApp {
 
-    override lazy val configuration: Configuration = new Configuration("", new PropertiesConfiguration() {
+    override lazy val configuration: Configuration = new Configuration("1.0.0", new PropertiesConfiguration() {
       addProperty("auth-info.url", "http://hostThatDoesNotExist:20170/")
       addProperty("auth-info.connection-timeout-ms", 2000)
       addProperty("auth-info.read-timeout-ms", 2000)

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
@@ -33,13 +33,6 @@ class UpdateServletSpec extends TestSupportFixture
   private val app = mock[TestApp]
   addServlet(new UpdateServlet(app), "/*")
 
-  "get /" should "return the message that the service is running" in {
-    get("/") {
-      body shouldBe s"EASY File Index is running v${ app.configuration.version }."
-      status shouldBe SC_OK
-    }
-  }
-
   "post /init[/:store]" should "return a feedback message for all stores" in {
     app.initAllStores _ expects() once() returning
       Success("xxx")

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
@@ -35,7 +35,7 @@ class UpdateServletSpec extends TestSupportFixture
 
   "get /" should "return the message that the service is running" in {
     get("/") {
-      body shouldBe "EASY File Index is running."
+      body shouldBe s"EASY File Index is running v${ app.configuration.version }."
       status shouldBe SC_OK
     }
   }


### PR DESCRIPTION
Fixes EASY-2002

#### When applied it will
* The baseUrl will not return "service is running v<version>."

- [x] ~~is the service is running + version required in the updateServlet?~~

- [x] remove running and version response from updateServlet

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?


