### PR TITLE
EASY-2056: use new servlet-logging features from dans-scala-lib v1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.5.0</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.json4s</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/EasySolr4FilesServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/EasySolr4FilesServlet.scala
@@ -22,11 +22,12 @@ import org.scalatra._
 class EasySolr4FilesServlet(app: EasySolr4filesIndexApp) extends ScalatraServlet
   with ServletLogger
   with PlainLogFormatter
+  with LogResponseBodyOnError
   with DebugEnhancedLogging {
   logger.info("File index Servlet running...")
 
   get("/") {
     contentType = "text/plain"
-    Ok(s"EASY File Index is running v${app.configuration.version}.").logResponse
+    Ok(s"EASY File Index is running v${app.configuration.version}.")
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/UpdateServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/UpdateServlet.scala
@@ -29,6 +29,7 @@ import scala.util.Try
 class UpdateServlet(app: EasySolr4filesIndexApp) extends ScalatraServlet
   with ServletLogger
   with PlainLogFormatter
+  with LogResponseBodyOnError
   with DebugEnhancedLogging {
   logger.info("File index Servlet running...")
 
@@ -59,44 +60,32 @@ class UpdateServlet(app: EasySolr4filesIndexApp) extends ScalatraServlet
   }
 
   post("/update/:store/:uuid") {
-    val result = getUUID
+    getUUID
       .map(uuid => respond(app.update(params("store"), uuid).map(_.msg)))
       .getOrRecover(badUuid)
-    logger.info(s"update returned ${ result.status } (${ result.body }) for $params")
-    result.logResponse
   }
 
   post("/init") {
-    val result = respond(app.initAllStores())
-    logger.info(s"update returned ${ result.status } (${ result.body }) for $params")
-    result.logResponse
+    respond(app.initAllStores())
   }
 
   post("/init/:store") {
-    val result = respond(app.initSingleStore(params("store")).map(_.msg))
-    logger.info(s"update returned ${ result.status } (${ result.body }) for $params")
-    result.logResponse
+    respond(app.initSingleStore(params("store")).map(_.msg))
   }
 
   delete("/:store/:uuid") {
-    val result = getUUID
+    getUUID
       .map(uuid => respond(app.delete(s"easy_dataset_id:$uuid")))
       .getOrRecover(badUuid)
-    logger.info(s"update returned ${ result.status } (${ result.body }) for $params")
-    result.logResponse
   }
 
   delete("/:store") {
-    val result = respond(app.delete(s"easy_dataset_store_id:${ params("store") }"))
-    logger.info(s"update returned ${ result.status } (${ result.body }) for $params")
-    result.logResponse
+    respond(app.delete(s"easy_dataset_store_id:${ params("store") }"))
   }
 
   delete("/") {
-    val result = params.get("q")
+    params.get("q")
       .map(q => respond(app.delete(q)))
       .getOrElse(BadRequest("delete requires param 'q', got " + params.asString))
-    logger.info(s"update returned ${ result.status } (${ result.body }) for $params")
-    result.logResponse
   }
 }


### PR DESCRIPTION
Fixes EASY-2056

#### When applied it will
* no longer use `.logResponse` to log the servlet response
* add `LogResponseBodyOnError` trait to servlet definition

@DANS-KNAW/easy for review