### PR TITLE
EASY-2021 Corrigeer aanroepen van bag-store op nieuwe percent-encoding regels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.5.0</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.json4s</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/AuthorisationComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/AuthorisationComponent.scala
@@ -20,6 +20,7 @@ import java.nio.file.Path
 import java.util.UUID
 
 import nl.knaw.dans.easy.solr4files._
+import nl.knaw.dans.lib.encode.PathEncoding
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.json4s.{ DefaultFormats, _ }
 
@@ -38,7 +39,7 @@ trait AuthorisationComponent extends DebugEnhancedLogging {
     private implicit val jsonFormats: Formats = DefaultFormats
 
     def getAuthInfoItem(bagId: UUID, path: Path): Try[AuthorisationItem] = {
-      val uri = baseUri.resolve(s"$bagId/${ escapePath(path) }")
+      val uri = baseUri.resolve(s"$bagId/${ path.escapePath }")
       for {
         jsonString <- http.getHttpAsString(uri, connectionTimeOutMs, readTimeOutMs)
         jsonOneLiner = jsonString.toOneLiner

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Vault.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Vault.scala
@@ -20,6 +20,7 @@ import java.nio.file.Paths
 import java.util.UUID
 
 import nl.knaw.dans.easy.solr4files._
+import nl.knaw.dans.lib.encode.PathEncoding
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 import scala.util.Try
@@ -51,7 +52,7 @@ trait Vault extends DebugEnhancedLogging {
   }
 
   def fileURL(storeName: String, bagId: UUID, file: String): Try[URL] = Try {
-    val f = escapePath(Paths.get(file))
+    val f = Paths.get(file).escapePath
     vaultBaseUri.resolve(s"stores/$storeName/bags/$bagId/$f").toURL
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
@@ -17,9 +17,7 @@ package nl.knaw.dans.easy
 
 import java.io.{ File, OutputStream }
 import java.net.{ URL, URLDecoder }
-import java.nio.file.Path
 
-import com.google.common.net.UrlEscapers
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.io.FileUtils.readFileToString
@@ -27,24 +25,18 @@ import org.apache.solr.common.util.NamedList
 import org.scalatra
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.{ Failure, Success, Try }
 import scala.xml.{ Elem, Node, XML }
 import scalaj.http.{ Http, HttpResponse }
 
 package object solr4files extends DebugEnhancedLogging {
-  private val pathEscaper = UrlEscapers.urlPathSegmentEscaper()
 
   type FeedBackMessage = String
   type SolrLiterals = Seq[(String, String)]
   type FileToShaMap = Map[String, String]
   type VocabularyMap = Map[String, String]
   type OutputStreamProvider = () => OutputStream
-
-  def escapePath(path: Path): String = {
-    path.asScala.map(_.toString).map(pathEscaper.escape).mkString("/")
-  }
 
   case class HttpStatusException(msg: String, response: HttpResponse[String])
     extends Exception(s"$msg - ${ response.statusLine }, details: ${ response.body }")


### PR DESCRIPTION
#### When applied it
* replaces calls to `Guava UrlEscapers` methods with calls to `dans-scala-lib `encoding methods
  (which in turn make use of `Guava PercentEscaper`)


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-auth-info                 | [DANS-KNAW/easy-auth-info/pull/23] | ..
easy-bag-store                | [DANS-KNAW/easy-bag-store/pull/91] | ..
easy-download                | [DANS-KNAW/easy-download/pull/33] | ..
easy-ingest-flow             | [DANS-KNAW/easy-ingest-flow/pull/109] | ..
easy-validate-dans-bag | [DANS-KNAW/easy-validate-dans-bag/pull/57] | ..