### PR TITLE
EASY-2139: easy-solr4files-index logging is niet duidelijk wanneer wordt gestopt met indexing als gevolg van een error

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.solr4files/EasySolr4filesIndexApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/EasySolr4filesIndexApp.scala
@@ -115,7 +115,7 @@ trait EasySolr4filesIndexApp extends ApplicationWiring with AutoCloseable
       .takeUntilFailure
       .doIfFailure { case MixedResultsException(results: Seq[_], e: Throwable) =>
         logger.error(e.getMessage)
-        logger.info("Indexing will be stopped. The files up till this error have been submitted; the list of submitted files here below:")
+        logger.info("Indexing has stopped, because one of the files could not be indexed. Only the following files are submitted:")
         results.foreach(fileFeedBack => logger.info(fileFeedBack.toString))
       }
       .map(results => BagSubmitted(bag.bagId.toString, results))

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/EasySolr4filesIndexApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/EasySolr4filesIndexApp.scala
@@ -113,7 +113,9 @@ trait EasySolr4filesIndexApp extends ApplicationWiring with AutoCloseable
       .flatMap(getFileItem(bag, _).toSeq) // skip the None's and unwrap the Some's
       .map(_.flatMap(createDoc(_, ddm))) // createDoc if getFileItem did not fail
       .takeUntilFailure
-      .doIfFailure { case MixedResultsException(results: Seq[_], _) =>
+      .doIfFailure { case MixedResultsException(results: Seq[_], e: Throwable) =>
+        logger.error(e.getMessage)
+        logger.info("Indexing will be stopped. The files up till this error have been submitted; the list of submitted files here below:")
         results.foreach(fileFeedBack => logger.info(fileFeedBack.toString))
       }
       .map(results => BagSubmitted(bag.bagId.toString, results))


### PR DESCRIPTION
Fixes EASY-2139

#### When applied it will
* give clearer error messages when indexing has to be stopped
* logs first the error and after that lists the files that up to this error have already been submitted


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
