### PR TITLE
EASY-2136: Content-Length header in easy-bag-store response

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
@@ -178,9 +178,9 @@ package object solr4files extends DebugEnhancedLogging {
       else {
         Try(http(left.toString).method("HEAD").asString).flatMap {
           case response if response.isSuccess =>
-            response.headers("content-length").headOption
+            response.header("File-Size")
               .map(cl => Success(cl.toLong))
-              .getOrElse(Failure(HttpStatusException(s"no content-length header found in response of $left", response)))
+              .getOrElse(Failure(HttpStatusException(s"no File-Size header found in response of $left", response)))
           case response => Failure(HttpStatusException(s"getContentLength($left)", response))
         }
       }


### PR DESCRIPTION
Fixes EASY-2136

#### When applied it will
* read the file size from `File-Size` header
* handle correctly the situation when the ` File-Size` header is absent

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-bag-store                      | [PR#93](https://github.com/DANS-KNAW/easy-bag-store/pull/93)     | ..
