### PR TITLE
EASY-2136: Content-Length header in easy-bag-store response

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Vault.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Vault.scala
@@ -49,7 +49,7 @@ trait Vault extends DebugEnhancedLogging {
     .map(str => UUID.fromString(str.trim))
 
   def getSize(storeName: String, bagId: UUID, path: String)(implicit http: BaseHttp): Long = {
-    fileURL(storeName, bagId, path).map(_.getContentLength).getOrElse(-1L)
+    fileURL(storeName, bagId, path).map(_.getFileSize).getOrElse(-1L)
   }
 
   def fileURL(storeName: String, bagId: UUID, file: String): Try[URL] = Try {

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
@@ -178,9 +178,9 @@ package object solr4files extends DebugEnhancedLogging {
       else {
         Try(http(left.toString).method("HEAD").asString).flatMap {
           case response if response.isSuccess =>
-            response.headers("content-length").headOption
+            response.header("File-Size")
               .map(cl => Success(cl.toLong))
-              .getOrElse(Failure(HttpStatusException(s"no content-length header found in response of $left", response)))
+              .getOrElse(Failure(HttpStatusException(s"no File-Size header found in response of $left", response)))
           case response => Failure(HttpStatusException(s"getContentLength($left)", response))
         }
       }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
@@ -172,14 +172,14 @@ package object solr4files extends DebugEnhancedLogging {
       }
     }
 
-    def getContentLength(implicit http: BaseHttp): Long = {
+    def getFileSize(implicit http: BaseHttp): Long = {
       if (left.getProtocol.toLowerCase == "file")
         Try(new File(left.getPath).length)
       else {
         val fileSizesUrl = left.toString.replace("bags", "bags/filesizes")
         Try(http(fileSizesUrl).method("GET").asString).flatMap {
-          case response if response.isSuccess => Success(response.body.toLong)
-          case response => Failure(HttpStatusException(s"get($fileSizesUrl)", response))
+          case response if response.isSuccess => Try { response.body.toLong }
+          case response => Failure(HttpStatusException(s"getFileSize($fileSizesUrl)", response))
         }
       }
     }.doIfFailure { case e => logger.warn(e.getMessage, e) }


### PR DESCRIPTION
Fixes EASY-2136

#### When applied 
* filesize of a file is queried through a specific url (.../bags/`filesizes`/path-to-the-file)
* the length of the file is returned in the response body

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-bag-store                      | [PR94](https://github.com/DANS-KNAW/easy-bag-store/pull/94)     | ..
