### PR TITLE
EASY-2140: CompositeException wordt niet goed afgehandeld in easy-solr4files-index

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.solr4files/EasySolr4filesIndexApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/EasySolr4filesIndexApp.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 import nl.knaw.dans.easy.solr4files.components._
 import nl.knaw.dans.lib.error.{ CompositeException, _ }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.apache.solr.client.solrj.SolrServerException
 import org.scalatra.auth.strategy.BasicAuthStrategy.BasicAuthRequest
 
 import scala.util.{ Failure, Success, Try }
@@ -54,6 +55,7 @@ trait EasySolr4filesIndexApp extends ApplicationWiring with AutoCloseable
   }.recoverWith {
     case t: SolrStatusException => commitAnyway(t) // just the delete
     case t: SolrUpdateException => commitAnyway(t) // just the delete
+    case MixedResultsException(_, e: SolrServerException) if e.getMessage contains "Server refused connection" => Failure(e)
     case t: MixedResultsException[_] => commitAnyway(t) // delete and some files
     case t => Failure(t)
   }


### PR DESCRIPTION
Fixes EASY-2140

#### When applied it will, when updating the store
* check if the last error in the `CompositeException` is `SolrServerException` and the error message contains string "`Server refused connection`"
* In that case a Failure is returned, without first trying to commit the changes that have been done so far

Notice: The second point in this issue was to check what are the other situations that cause the `CompositeException` and whether there would be a better error message than `InternalServerError`.
Also in other situations the only exception that is thrown is the `SolrServerException`, and the best option is then to return `InternalServerError`.

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
