### PR TITLE
EASY-2137: make metadata fetch timeout configurable

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -9,6 +9,8 @@ auth-info.connection-timeout-ms=2000
 auth-info.read-timeout-ms=2000
 list-bags.connection-timeout-ms=600000
 list-bags.read-timeout-ms=600000
+fetch-metadata.connection-timeout-ms=600000
+fetch-metadata.read-timeout-ms=600000
 
 ldap.provider.url=ldap://localhost
 # TODO: this is not actually a "reasonable default", as it is DANS-specific, so it should be replaced by something like 'ou=users, dc=yourdomain-here, dc=org'

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/ApplicationWiring.scala
@@ -59,4 +59,7 @@ trait ApplicationWiring
   // Cannot use properties.getList in the following line because we do not parse commas. Parsing commas conflicts with having LDAP DNs as values.
   override val mimeTypesToExtractContentFrom: Seq[String] = configuration.properties.getString("file-content-extraction.mime-types", "").split(Array(' ', ','))
   override val maxFileSizeToExtractContentFrom: Double = configuration.properties.getString("file-content-extraction.max-filesize", (64 * 1024 * 1024).toString).toDouble
+
+  val fetchMetadataConnTimeoutMs: Int = configuration.properties.getInt("fetch-metadata.connection-timeout-ms")
+  val fetchMetadataReadTimeoutMs: Int = configuration.properties.getInt("fetch-metadata.read-timeout-ms")
 }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/EasySolr4filesIndexApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/EasySolr4filesIndexApp.scala
@@ -42,9 +42,9 @@ trait EasySolr4filesIndexApp extends ApplicationWiring with AutoCloseable
   def update(storeName: String, bagId: UUID): Try[BagSubmitted] = {
     val bag = Bag(storeName, bagId, this)
     for {
-      ddmXML <- bag.loadDDM
+      ddmXML <- bag.loadDDM(fetchMetadataConnTimeoutMs, fetchMetadataReadTimeoutMs)
       ddm = new DDM(ddmXML)
-      filesXML <- bag.loadFilesXML
+      filesXML <- bag.loadFilesXML(fetchMetadataConnTimeoutMs, fetchMetadataReadTimeoutMs)
       _ = logger.info(s"deleted documents of $bagId")
       _ <- deleteDocuments(s"id:${ bag.bagId }*")
       feedbackMessage <- updateFiles(bag, ddm, filesXML)

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Bag.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Bag.scala
@@ -59,11 +59,11 @@ case class Bag(storeName: String,
     fileShas.getOrElse(path, "")
   }
 
-  def loadDDM: Try[Elem] = vault
+  def loadDDM(connTimeoutMs: Int = defaultConnTimeout, readTimeoutMs: Int = defaultReadTimeout): Try[Elem] = vault
     .fileURL(storeName, bagId, "metadata/dataset.xml")
-    .flatMap(_.loadXml())
+    .flatMap(_.loadXml(connTimeoutMs, readTimeoutMs))
 
-  def loadFilesXML: Try[Elem] = vault
+  def loadFilesXML(connTimeoutMs: Int = defaultConnTimeout, readTimeoutMs: Int = defaultReadTimeout): Try[Elem] = vault
     .fileURL(storeName, bagId, "metadata/files.xml")
-    .flatMap(_.loadXml())
+    .flatMap(_.loadXml(connTimeoutMs, readTimeoutMs))
 }

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -9,6 +9,8 @@ auth-info.connection-timeout-ms=2000
 auth-info.read-timeout-ms=2000
 list-bags.connection-timeout-ms=600000
 list-bags.read-timeout-ms=600000
+fetch-metadata.connection-timeout-ms=600000
+fetch-metadata.read-timeout-ms=600000
 
 ldap.provider.url=ldap://deasy.dans.knaw.nl:389
 # TODO: this is not actually a "reasonable default", as it is DANS-specific, so it should be replaced by something like 'ou=users, dc=yourdomain-here, dc=org'

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/TestSupportFixture.scala
@@ -47,6 +47,8 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
       addProperty("auth-info.read-timeout-ms", 2000)
       addProperty("list-bags.connection-timeout-ms", 10000)
       addProperty("list-bags.read-timeout-ms", 10000)
+      addProperty("fetch-metadata.connection-timeout-ms", 10000)
+      addProperty("fetch-metadata.read-timeout-ms", 10000)
     })
 
     override val maxFileSizeToExtractContentFrom: Double = 64 * 1024 * 1024


### PR DESCRIPTION
Fixes EASY-2137

#### When applied it will
* make metadata fetch timeout configurable

@DANS-KNAW/easy for review