### PR TITLE
EASY-2450: custom license in header bij file download vanuit easy-download

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/AuthorisationItem.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/AuthorisationItem.scala
@@ -34,7 +34,7 @@ case class AuthorisationItem(itemId: String,
                              accessibleTo: RightsFor.Value,
                              visibleTo: RightsFor.Value,
                              licenseKey: String,
-                             licenseTitle: String
+                             licenseTitle: String,
                        ) {
   val isAccessible: Boolean = {
     accessibleTo != RightsFor.NONE

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/AuthorisationItem.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/AuthorisationItem.scala
@@ -32,7 +32,9 @@ case class AuthorisationItem(itemId: String,
                              owner: String,
                              dateAvailable: DateTime,
                              accessibleTo: RightsFor.Value,
-                             visibleTo: RightsFor.Value
+                             visibleTo: RightsFor.Value,
+                             licenseKey: String,
+                             licenseTitle: String
                        ) {
   val isAccessible: Boolean = {
     accessibleTo != RightsFor.NONE

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/AppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/AppSpec.scala
@@ -83,6 +83,8 @@ class AppSpec extends TestSupportFixture {
        |  "dateAvailable":"1992-07-30",
        |  "accessibleTo":"ANONYMOUS",
        |  "visibleTo":"ANONYMOUS"
+       |  "licenseKey":"http://creativecommons.org/publicdomain/zero/1.0",
+       |  "licenseTitle":"CC0-1.0.html"
        |}""".stripMargin)
 
   "update" should "call the stubbed solrClient.request" in {
@@ -141,6 +143,8 @@ class AppSpec extends TestSupportFixture {
          |  "dateAvailable":"1992-07-30",
          |  "accessibleTo":"NONE",
          |  "visibleTo":"NONE"
+         |  "licenseKey":"http://opensource.org/licenses/MIT",
+         |  "licenseTitle":"MIT.txt"
          |}""".stripMargin)
     ) once()
     class MockedBag extends Bag("pdbs", uuid, mock[Vault])

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
@@ -82,7 +82,9 @@ class SolrErrorHandlingSpec extends TestSupportFixture
          |  "owner":"someone",
          |  "dateAvailable":"1992-07-30",
          |  "accessibleTo":"ANONYMOUS",
-         |  "visibleTo":"ANONYMOUS"
+         |  "visibleTo":"ANONYMOUS",
+         |  "licenseKey":"http://creativecommons.org/publicdomain/zero/1.0",
+         |  "licenseTitle":"CC0-1.0.html"
          |}""".stripMargin))
     initVault()
     post(s"/fileindex/update/pdbs/${ uuidCentaur }") {

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/components/FileItemSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/components/FileItemSpec.scala
@@ -51,7 +51,7 @@ class FileItemSpec extends TestSupportFixture {
       dateAvailable = DateTime.now,
       accessibleTo = RESTRICTED_GROUP,
       visibleTo = RESTRICTED_GROUP,
-      licenseKey = "http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSGeneralconditionsofuseUKDEF.pdf",
+      licenseKey = "http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/dans-licence.pdf=DANS_Licence_UK.pdf",
       licenseTitle = "DANS_Licence_UK.pdf"
     )
     val solrLiterals = FileItem(mockedBag, (xml \ "title").text, (xml \ "format").text, authInfoItem).solrLiterals.toMap

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/components/FileItemSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/components/FileItemSpec.scala
@@ -50,7 +50,9 @@ class FileItemSpec extends TestSupportFixture {
       owner = "someone",
       dateAvailable = DateTime.now,
       accessibleTo = RESTRICTED_GROUP,
-      visibleTo = RESTRICTED_GROUP
+      visibleTo = RESTRICTED_GROUP,
+      licenseKey = "http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSGeneralconditionsofuseUKDEF.pdf",
+      licenseTitle = "DANS_Licence_UK.pdf"
     )
     val solrLiterals = FileItem(mockedBag, (xml \ "title").text, (xml \ "format").text, authInfoItem).solrLiterals.toMap
     solrLiterals("file_path") shouldBe filePath


### PR DESCRIPTION
Fixes EASY-2450

#### When applied it will
* add `license key` and `license title` into `AuthorisationItem`

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-auth-info                      | [PR#33](https://github.com/DANS-KNAW/easy-auth-info/pull/33)     | 
easy-download                      | [PR#42](https://github.com/DANS-KNAW/easy-download/pull/42)     | ..
