### PR TITLE
EASY-2332: validation of UUIDs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.6.0</version>
+            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>org.json4s</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/CommandLineOptions.scala
@@ -17,7 +17,8 @@ package nl.knaw.dans.easy.solr4files
 
 import java.util.UUID
 
-import org.rogach.scallop.{ ScallopConf, ScallopOption, Subcommand, ValueConverter, singleArgConverter }
+import nl.knaw.dans.lib.string._
+import org.rogach.scallop.{ ScallopConf, ScallopOption, Subcommand, ValueConverter, stringConverter }
 
 class CommandLineOptions(args: Array[String], configuration: Configuration) extends ScallopConf(args) {
   type StoreName = String
@@ -57,11 +58,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
 
   private val defaultBagStore = Some(configuration.properties.getString("default.bag-store", "MISSING_BAG_STORE"))
 
-  private implicit def bagId: ValueConverter[UUID] = {
-    singleArgConverter {
-      case s => UUID.fromString(s)
-    }
-  }
+  private implicit def uuidConverter: ValueConverter[UUID] = stringConverter.flatMap(_.toUUID.fold(e => Left(e.getMessage), uuid => Right(Option(uuid))))
 
   val update = new Subcommand("update") {
     descr("Update accessible files of a bag in the SOLR index")

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/UpdateServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/UpdateServlet.scala
@@ -15,11 +15,10 @@
  */
 package nl.knaw.dans.easy.solr4files
 
-import java.util.UUID
-
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.lib.logging.servlet._
+import nl.knaw.dans.lib.string._
 import org.apache.http.HttpStatus._
 import org.scalatra._
 import scalaj.http.HttpResponse
@@ -50,7 +49,7 @@ class UpdateServlet(app: EasySolr4filesIndexApp) extends ScalatraServlet
   }
 
   private def getUUID = {
-    Try { UUID.fromString(params("uuid")) }
+    params("uuid").toUUID.toTry
   }
 
   private def badUuid(e: Throwable) = {

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/UpdateServletSpec.scala
@@ -76,7 +76,7 @@ class UpdateServletSpec extends TestSupportFixture
 
   it should "return BAD REQUEST with an invalid uuid" in {
     post("/update/pdbs/rabarbera") {
-      body shouldBe "Invalid UUID string: rabarbera"
+      body shouldBe "String 'rabarbera' is not a UUID"
       status shouldBe SC_BAD_REQUEST
     }
   }
@@ -161,7 +161,7 @@ class UpdateServletSpec extends TestSupportFixture
 
   it should "return BAD REQUEST with an invalid UUID" in {
     delete("/pdbs/rabarbera") {
-      body shouldBe "Invalid UUID string: rabarbera"
+      body shouldBe "String 'rabarbera' is not a UUID"
       status shouldBe SC_BAD_REQUEST
     }
   }


### PR DESCRIPTION
Fixes EASY-2332

#### When applied it will
* validate `UUIDs` using `dans.lib.string.toUUID` method

**Note**: In the following classes `UUID` is created directly by calling `UUID.fromString` method because these bagId-strings come from already existing bags:
* Vault
#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-archive-bag   | [PR#66](https://github.com/DANS-KNAW/easy-archive-bag/pull/66)     | ..
easy-auth-info   | [PR#36](https://github.com/DANS-KNAW/easy-auth-info/pull/36)     | ..
easy-bag-index  | [PR#50](https://github.com/DANS-KNAW/easy-bag-index/pull/50)     | ..
easy-bag-store  | [PR#100](https://github.com/DANS-KNAW/easy-bag-store/pull/100)     | ..
easy-delete-dataset  | [PR#19](https://github.com/DANS-KNAW/easy-delete-dataset/pull/19)     | ..
easy-deposit-api  | [PR#204](https://github.com/DANS-KNAW/easy-deposit-api/pull/204)     | ..
easy-deposit-properties  | [PR#23](https://github.com/DANS-KNAW/easy-deposit-properties/pull/23)     | ..
easy-ingest-flow  | [PR#137](https://github.com/DANS-KNAW/easy-ingest-flow/pull/137)     | ..
easy-split-multi-deposit  | [PR#146](https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/146)     | ..
easy-transform-metadata  | [PR#11](https://github.com/DANS-KNAW/easy-transform-metadata/pull/11)     | ..
easy-validate-dans-bag  | [PR#73](https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/73)     | ..

