### PR TITLE
EASY-1945: upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,6 @@
             -->
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
-            <version>6.6.0</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>org.json4s</groupId>
@@ -98,7 +97,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
@@ -132,7 +130,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>20.0</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/AuthenticationComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/AuthenticationComponent.scala
@@ -95,7 +95,6 @@ trait AuthenticationComponent extends DebugEnhancedLogging {
         searchResult <- getFirst(searchResults.asScala.toList)
         userAttributes = searchResult.getAttributes.getAll.asScala.map(toTuples).toMap
         _ <- userIsActive(userAttributes)
-        roles = userAttributes.getOrElse("easyRoles", Seq.empty)
       } yield User(userName, userAttributes.getOrElse("easyGroups", Seq.empty))
     }
   }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/AuthorisationItem.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/AuthorisationItem.scala
@@ -15,9 +15,7 @@
  */
 package nl.knaw.dans.easy.solr4files.components
 
-import java.nio.file.{ Path, Paths }
 import java.text.SimpleDateFormat
-import java.util.UUID
 
 import nl.knaw.dans.easy.solr4files._
 import org.joda.time.DateTime
@@ -35,7 +33,7 @@ case class AuthorisationItem(itemId: String,
                              visibleTo: RightsFor.Value,
                              licenseKey: String,
                              licenseTitle: String,
-                       ) {
+                            ) {
   val isAccessible: Boolean = {
     accessibleTo != RightsFor.NONE
   }

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -21,7 +21,7 @@ import nl.knaw.dans.easy.solr4files._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.http.HttpStatus._
 import org.apache.solr.client.solrj.SolrRequest.METHOD
-import org.apache.solr.client.solrj.impl.HttpSolrClient
+import org.apache.solr.client.solrj.impl.BaseHttpSolrClient
 import org.apache.solr.client.solrj.request.ContentStreamUpdateRequest
 import org.apache.solr.client.solrj.response.{ SolrResponseBase, UpdateResponse }
 import org.apache.solr.client.solrj.{ SolrClient, SolrQuery }
@@ -80,7 +80,7 @@ trait Solr extends DebugEnhancedLogging {
     Try(solrClient.deleteByQuery(q.getQuery))
       .flatMap(checkResponseStatus)
       .recoverWith {
-        case t: HttpSolrClient.RemoteSolrException if isParseException(t) =>
+        case t: BaseHttpSolrClient.RemoteSolrException if isParseException(t) =>
           Failure(SolrBadRequestException(t.getMessage, t))
         case t =>
           Failure(SolrDeleteException(query, t))
@@ -113,14 +113,14 @@ trait Solr extends DebugEnhancedLogging {
       fileItems = fileItemsAsJson(results, skipFetched)
     } yield toJson(query, results.getNumFound, fileItems) // .getFacet.Xxx, .getGroupXxx .getSortedXxx .getMoreLikeXxx etc.
       ).recoverWith {
-      case t: HttpSolrClient.RemoteSolrException if isParseException(t) =>
+      case t: BaseHttpSolrClient.RemoteSolrException if isParseException(t) =>
         Failure(SolrBadRequestException(t.getMessage, t))
       case t =>
         Failure(SolrSearchException(query.toQueryString, t))
     }
   }
 
-  private def isParseException(t: HttpSolrClient.RemoteSolrException) = {
+  private def isParseException(t: BaseHttpSolrClient.RemoteSolrException) = {
     t.getRootThrowable.endsWith("ParseException")
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -21,7 +21,7 @@ import nl.knaw.dans.easy.solr4files._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.http.HttpStatus._
 import org.apache.solr.client.solrj.SolrRequest.METHOD
-import org.apache.solr.client.solrj.impl.{ BaseHttpSolrClient, HttpSolrClient }
+import org.apache.solr.client.solrj.impl.HttpSolrClient
 import org.apache.solr.client.solrj.request.ContentStreamUpdateRequest
 import org.apache.solr.client.solrj.response.{ SolrResponseBase, UpdateResponse }
 import org.apache.solr.client.solrj.{ SolrClient, SolrQuery }
@@ -113,14 +113,14 @@ trait Solr extends DebugEnhancedLogging {
       fileItems = fileItemsAsJson(results, skipFetched)
     } yield toJson(query, results.getNumFound, fileItems) // .getFacet.Xxx, .getGroupXxx .getSortedXxx .getMoreLikeXxx etc.
       ).recoverWith {
-      case t: BaseHttpSolrClient.RemoteSolrException if isParseException(t) =>
+      case t: HttpSolrClient.RemoteSolrException if isParseException(t) =>
         Failure(SolrBadRequestException(t.getMessage, t))
       case t =>
         Failure(SolrSearchException(query.toQueryString, t))
     }
   }
 
-  private def isParseException(t: BaseHttpSolrClient.RemoteSolrException) = {
+  private def isParseException(t: HttpSolrClient.RemoteSolrException) = {
     t.getRootThrowable.endsWith("ParseException")
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/components/Solr.scala
@@ -21,7 +21,7 @@ import nl.knaw.dans.easy.solr4files._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.http.HttpStatus._
 import org.apache.solr.client.solrj.SolrRequest.METHOD
-import org.apache.solr.client.solrj.impl.HttpSolrClient
+import org.apache.solr.client.solrj.impl.{ BaseHttpSolrClient, HttpSolrClient }
 import org.apache.solr.client.solrj.request.ContentStreamUpdateRequest
 import org.apache.solr.client.solrj.response.{ SolrResponseBase, UpdateResponse }
 import org.apache.solr.client.solrj.{ SolrClient, SolrQuery }
@@ -113,14 +113,14 @@ trait Solr extends DebugEnhancedLogging {
       fileItems = fileItemsAsJson(results, skipFetched)
     } yield toJson(query, results.getNumFound, fileItems) // .getFacet.Xxx, .getGroupXxx .getSortedXxx .getMoreLikeXxx etc.
       ).recoverWith {
-      case t: HttpSolrClient.RemoteSolrException if isParseException(t) =>
+      case t: BaseHttpSolrClient.RemoteSolrException if isParseException(t) =>
         Failure(SolrBadRequestException(t.getMessage, t))
       case t =>
         Failure(SolrSearchException(query.toQueryString, t))
     }
   }
 
-  private def isParseException(t: HttpSolrClient.RemoteSolrException) = {
+  private def isParseException(t: BaseHttpSolrClient.RemoteSolrException) = {
     t.getRootThrowable.endsWith("ParseException")
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
@@ -119,8 +119,8 @@ package object solr4files extends DebugEnhancedLogging {
   }
 
   implicit class RichParams(val left: scalatra.Params) extends AnyVal {
-    def asString: String = if (left.isEmpty) "no params at all"
-                           else "params " + left.mkString("[", ",", "]")
+    def asString: String = if (left.size == 0) "no params at all"
+                           else "params " + left.toMap.mkString("[", ",", "]")
   }
 
   val xsiURI = "http://www.w3.org/2001/XMLSchema-instance"

--- a/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr4files/package.scala
@@ -119,8 +119,8 @@ package object solr4files extends DebugEnhancedLogging {
   }
 
   implicit class RichParams(val left: scalatra.Params) extends AnyVal {
-    def asString: String = if (left.size == 0) "no params at all"
-                           else "params " + left.toMap.mkString("[", ",", "]")
+    def asString: String = if (left.isEmpty) "no params at all"
+                           else "params " + left.mkString("[", ",", "]")
   }
 
   val xsiURI = "http://www.w3.org/2001/XMLSchema-instance"

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/AppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/AppSpec.scala
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.easy.solr4files
 
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 import nl.knaw.dans.easy.solr4files.components._
@@ -154,8 +155,8 @@ class AppSpec extends TestSupportFixture {
 
   it should "report problems when easy-auth-info returns invalid content" in {
     clearVault()
-    write(testDir.resolve(s"vault/stores/pdbs/bags/$uuid/metadata/dataset.xml").toFile, "<ddm/>")
-    write(testDir.resolve(s"vault/stores/pdbs/bags/$uuid/metadata/files.xml").toFile, "<files><file filepath='xy.z'/></files>")
+    write(testDir.resolve(s"vault/stores/pdbs/bags/$uuid/metadata/dataset.xml").toFile, "<ddm/>", StandardCharsets.UTF_8)
+    write(testDir.resolve(s"vault/stores/pdbs/bags/$uuid/metadata/files.xml").toFile, "<files><file filepath='xy.z'/></files>", StandardCharsets.UTF_8)
     val authInfoJson = """{ "visibleTo":"ANONYMOUS" }""".stripMargin
     val app = new StubbedSolrApp()
     app.expectsHttpAsString(Success(authInfoJson))
@@ -199,7 +200,8 @@ class AppSpec extends TestSupportFixture {
         |    24d305fc-060c-4b3b-a5f5-9f212d463cbc
         |    3528bd4c-a87a-4bfa-9741-a25db7ef758a
         |    f70c19a5-0725-4950-aa42-6489a9d73806
-        |    6ccadbad-650c-47ec-936d-2ef42e5f3cda""".stripMargin
+        |    6ccadbad-650c-47ec-936d-2ef42e5f3cda""".stripMargin,
+      StandardCharsets.UTF_8
     )
     val result = new StubbedSolrApp() {
       // vaultBagIds/bags can't be a file and directory so we need a mockedDDM, a failure demonstrates it's called
@@ -217,7 +219,8 @@ class AppSpec extends TestSupportFixture {
       """    <http://localhost:20110/stores/foo>
         |    <http://localhost:20110/stores/bar>
         |    <http://localhost:20110/stores/rabarbera>
-        |    <http://localhost:20110/stores/barbapapa>""".stripMargin
+        |    <http://localhost:20110/stores/barbapapa>""".stripMargin,
+      StandardCharsets.UTF_8
     )
     val result = new StubbedSolrApp() {
 

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/AppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/AppSpec.scala
@@ -63,7 +63,7 @@ class AppSpec extends TestSupportFixture {
   }
 
   private def nrOfImageStreams(solrRequest: SolrRequest[_ <: SolrResponse]) = {
-    if (solrRequest.getContentStreams.isEmpty)
+    if (solrRequest.getContentWriter(String).toString.isEmpty)
       0
     else {
       val solrDocId = solrRequest

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/AppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/AppSpec.scala
@@ -63,7 +63,7 @@ class AppSpec extends TestSupportFixture {
   }
 
   private def nrOfImageStreams(solrRequest: SolrRequest[_ <: SolrResponse]) = {
-    if (solrRequest.getContentWriter(String).toString.isEmpty)
+    if (solrRequest.getContentWriter("").toString.isEmpty)
       0
     else {
       val solrDocId = solrRequest

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/AppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/AppSpec.scala
@@ -63,7 +63,7 @@ class AppSpec extends TestSupportFixture {
   }
 
   private def nrOfImageStreams(solrRequest: SolrRequest[_ <: SolrResponse]) = {
-    if (solrRequest.getContentWriter("").toString.isEmpty)
+    if (solrRequest.getContentStreams.isEmpty)
       0
     else {
       val solrDocId = solrRequest

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/ReadmeSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/ReadmeSpec.scala
@@ -19,10 +19,11 @@ import java.io.{ ByteArrayOutputStream, File }
 import java.nio.file.Paths
 
 import org.scalatest._
+import resource.managed
 
 import scala.io.Source
 
-class FReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
+class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
 
   private val configuration = Configuration(Paths.get("src/main/assembly/dist"))
   private val clo = new CommandLineOptions(Array[String](), configuration) {
@@ -55,7 +56,7 @@ class FReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
   }
 
   "user filters" should "be listed in docs/api/api.yml" in {
-    val readme = Source.fromFile(new File("docs/api/api.yml")).mkString
+    val readme = managed { Source.fromFile(new File("docs/api/api.yml")) }.acquireAndGet(_.mkString)
     SearchServlet.userFilters.foreach(
       s => readme should include(s)
     )

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/SearchServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/SearchServletSpec.scala
@@ -31,7 +31,7 @@ class SearchServletSpec extends TestSupportFixture
   with ScalatraSuite
   with MockFactory {
 
-  private val testApp = new TestApp() {
+  private val testApp: TestApp = new TestApp() {
     override val solrClient: SolrClient = new SolrClient() {
       // can't use mock because SolrClient has a final method
 

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
@@ -68,8 +68,8 @@ class SolrErrorHandlingSpec extends TestSupportFixture
 
   "delete" should "return the exception bubbling up from solrClient.deleteByQuery" in {
     delete("/fileindex/?q=:") {
-      body shouldBe "solr delete [:] failed with Error from server at mockedHost: mocked parser"
-      status shouldBe SC_INTERNAL_SERVER_ERROR
+      body shouldBe "Error from server at mockedHost: mocked parser"
+      status shouldBe SC_BAD_REQUEST
     }
   }
 
@@ -95,8 +95,8 @@ class SolrErrorHandlingSpec extends TestSupportFixture
 
   "search" should "return the exception bubbling up from solrClient.query" in {
     get(s"/filesearch?text=:") {
-      body shouldBe ""
-      status shouldBe SC_INTERNAL_SERVER_ERROR
+      body shouldBe "Error from server at mockedHost: mocked parser"
+      status shouldBe SC_BAD_REQUEST
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
@@ -16,7 +16,7 @@
 package nl.knaw.dans.easy.solr4files
 
 import org.apache.http.HttpStatus._
-import org.apache.solr.client.solrj.impl.HttpSolrClient
+import org.apache.solr.client.solrj.impl.{ BaseHttpSolrClient, HttpSolrClient }
 import org.apache.solr.client.solrj.response.{ QueryResponse, UpdateResponse }
 import org.apache.solr.client.solrj.{ SolrClient, SolrRequest, SolrResponse }
 import org.apache.solr.common.SolrInputDocument
@@ -55,7 +55,7 @@ class SolrErrorHandlingSpec extends TestSupportFixture
         throw new Exception("mocked request")
 
       private def mockParseException = {
-        new HttpSolrClient.RemoteSolrException("mockedHost", 0, "mocked parser", new Exception()) {
+        new BaseHttpSolrClient.RemoteSolrException("mockedHost", 0, "mocked parser", new Exception()) {
           // try the query manually at deasy.dans.knaw.nl:8983/solr/#/fileitems/query
           // and see error.metadata.root-error-class in the response
           override def getRootThrowable: String = "org.apache.solr.parser.ParseException"

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/SolrErrorHandlingSpec.scala
@@ -16,7 +16,7 @@
 package nl.knaw.dans.easy.solr4files
 
 import org.apache.http.HttpStatus._
-import org.apache.solr.client.solrj.impl.{ BaseHttpSolrClient, HttpSolrClient }
+import org.apache.solr.client.solrj.impl.BaseHttpSolrClient
 import org.apache.solr.client.solrj.response.{ QueryResponse, UpdateResponse }
 import org.apache.solr.client.solrj.{ SolrClient, SolrRequest, SolrResponse }
 import org.apache.solr.common.SolrInputDocument
@@ -68,8 +68,8 @@ class SolrErrorHandlingSpec extends TestSupportFixture
 
   "delete" should "return the exception bubbling up from solrClient.deleteByQuery" in {
     delete("/fileindex/?q=:") {
-      body shouldBe "Error from server at mockedHost: mocked parser"
-      status shouldBe SC_BAD_REQUEST
+      body shouldBe "solr delete [:] failed with Error from server at mockedHost: mocked parser"
+      status shouldBe SC_INTERNAL_SERVER_ERROR
     }
   }
 
@@ -95,8 +95,8 @@ class SolrErrorHandlingSpec extends TestSupportFixture
 
   "search" should "return the exception bubbling up from solrClient.query" in {
     get(s"/filesearch?text=:") {
-      body shouldBe "Error from server at mockedHost: mocked parser"
-      status shouldBe SC_BAD_REQUEST
+      body shouldBe ""
+      status shouldBe SC_INTERNAL_SERVER_ERROR
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.solr4files/components/VaultSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr4files/components/VaultSpec.scala
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.easy.solr4files.components
 
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 import nl.knaw.dans.easy.solr4files.TestSupportFixture
@@ -33,7 +34,8 @@ class VaultSpec extends TestSupportFixture {
       """    <http://localhost:20110/stores/foo>
         |    <http://localhost:20110/stores/bar>
         |    <http://localhost:20110/stores/rabarbera>
-        |    <http://localhost:20110/stores/barbapapa>""".stripMargin
+        |    <http://localhost:20110/stores/barbapapa>""".stripMargin,
+      StandardCharsets.UTF_8
     )
     inside(mockedVault.getStoreNames) {
       case Success(names) => names should contain only("foo", "bar", "rabarbera", "barbapapa")
@@ -47,7 +49,8 @@ class VaultSpec extends TestSupportFixture {
         |    24d305fc-060c-4b3b-a5f5-9f212d463cbc
         |    3528bd4c-a87a-4bfa-9741-a25db7ef758a
         |    f70c19a5-0725-4950-aa42-6489a9d73806
-        |    6ccadbad-650c-47ec-936d-2ef42e5f3cda""".stripMargin
+        |    6ccadbad-650c-47ec-936d-2ef42e5f3cda""".stripMargin,
+      StandardCharsets.UTF_8
     )
     inside(mockedVault.getBagIds("pdbs")) {
       case Success(names) => names should contain only(


### PR DESCRIPTION
Fixes EASY-1945

#### When applied it will
* upgrade parent POM version
* remove self-contained dependency version tags
* fix issues caused by breaking changes of dependency updates